### PR TITLE
Fix test templates

### DIFF
--- a/app/templates/sometest/make_mc12101_nmpu0/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu0/Makefile
@@ -17,7 +17,7 @@ endif
 
 
 INC_DIRS = -I"$(NMPP)/include" -I"$(MC12101)/include" -I"$(NEURO)/include" -I"$(HAL)/include" -I../../../../include
-SRC_DIRS = ../../../../src_proc0/nm
+SRC_DIRS = ../../../../src_proc0/nm ..
 LIB_DIRS = -L"$(NMPP)/lib"     -L"$(MC12101)/lib" -L$(HAL)/lib -L"$(NEURO)/lib"
 LIBS     = mc12101lib_nm.lib libc4f.lib libc4.lib nmpp-nmc4f.lib hal-mc12101.lib
 TARGET   = main.abs

--- a/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
@@ -49,7 +49,7 @@
 include $(ROOT)/global.mk
 include 		 nmc4vars_win.mk
 #-------------- target & input dirs -------------------
-PROJECT          = main1
+PROJECT          = main0
 OUT_DIR          = .
 TARGET           = $(OUT_DIR)/$(PROJECT).abs
 INC_DIRS         = -I"$(NMPP)/include" -I$(HAL)/include -I$(ROOT)/include

--- a/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
@@ -60,6 +60,7 @@ TMP_DIR          = Release
 CC 				 = nmc-g++
 AS               = nmc-gcc 				 
 AS_FLAGS    	 = -c -mmas -x assembler -Wa,-split_sir -mnmc4-float
+CC_FLAGS		 = -std=c++11
 LIBS             = -lnmpp-nmc4f -lhal-mc12101
 LINKER_FLAGS     =   -Xlinker -Map=.main0.map $(LIB_DIRS) "-Wl,-cmc12101brd-nmpu0.cfg"  -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o$(TARGET)
 #=================== SOURCE & OBJECTS COLLECTION ===========================

--- a/app/templates/sometest/make_mc12101_nmpu1/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu1/Makefile
@@ -17,7 +17,7 @@ endif
 
 
 INC_DIRS = -I"$(NMPP)/include" -I"$(MC12101)/include" -I"$(NEURO)/include" -I"$(HAL)/include" -I../../../../include
-SRC_DIRS = ../../../../src_proc1/nm
+SRC_DIRS = ../../../../src_proc1/nm ..
 LIB_DIRS = -L"$(NMPP)/lib"     -L"$(MC12101)/lib" -L$(HAL)/lib -L"$(NEURO)/lib"
 LIBS     = mc12101lib_nm.lib libc4f.lib libc4.lib nmpp-nmc4.lib hal-mc12101.lib
 TARGET   = main.abs

--- a/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
@@ -61,6 +61,7 @@ TMP_DIR          = Release
 CC 				 = nmc-g++
 AS               = nmc-gcc 				 
 AS_FLAGS    	 = -c -mmas -x assembler -Wa,-split_sir -mnmc4-fixed
+CC_FLAGS		 = -std=c++11
 LIBS             = -lnmpp-nmc4 -lhal-mc12101
 LINKER_FLAGS     =   -Xlinker -Map=.main1.map $(LIB_DIRS) "-Wl,-cmc12101brd-nmpu1.cfg"  -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o$(TARGET)
 #=================== SOURCE & OBJECTS COLLECTION ===========================

--- a/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
@@ -94,6 +94,9 @@ all:  $(TARGET)
 	
 #	$(MAKE) -j4 DEBUG=y
 #	$(MAKE) -j4
+
+run: $(TARGET)
+	mc12101run $(TARGET) -p
 	
 $(TMP_DIR):
 	-mkdir "$(@)"

--- a/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
@@ -54,7 +54,7 @@ PROJECT          = main1
 OUT_DIR          = .
 TARGET           = $(OUT_DIR)/$(PROJECT).abs
 INC_DIRS         = -I"$(NMPP)/include" -I$(HAL)/include -I$(ROOT)/include
-SRC_DIRS 		 = $(ROOT)/src_proc1/nm
+SRC_DIRS 		 = $(ROOT)/src_proc1/nm ..
 LIB_DIRS         = -L "$(NMC_GCC_TOOLPATH)/nmc4-ide/lib" -L"$(NMPP)/lib" -L"$(HAL)/lib"
 TMP_DIR          = Release
 #-------------- RELEASE/ALL config -------------------
@@ -93,7 +93,6 @@ all:  $(TARGET)
 	
 #	$(MAKE) -j4 DEBUG=y
 #	$(MAKE) -j4
-
 	
 $(TMP_DIR):
 	-mkdir "$(@)"


### PR DESCRIPTION
Изменения корректируют сборку и запуск тестов, в частности для платформ mc12101_nmpu0_gcc и mc12101_nmpu1_gcc. 

Изменения предлагаю сразу в master потому, что далее хочу актуальную версию master слить в textures. А затем уже добавлять сервисные функции с тестами в textures.
