### PR TITLE
Fix test macro to make vertexPrimitiveRepack tests work

### DIFF
--- a/include/tests.h
+++ b/include/tests.h
@@ -61,7 +61,7 @@ if (!x) \
 }
 #define TEST_VEC_ARRAYS_EQUAL(array1, array2, size) \
 { \
-	int __i; \
+	volatile int __i; \
 	for (__i = 0; __i < size; ++__i){ \
 		if ((!equalf(array1[__i].vec[0], array2[__i].vec[0])) || \
 			(!equalf(array1[__i].vec[1], array2[__i].vec[1])) || \


### PR DESCRIPTION
That is on of the ways to make the tests work. All service functions pass the tests for mc12101_nmpu0/1_gcc and x86 platforms