### PR TITLE
nmglTexCoordPointer implementation

### DIFF
--- a/include/nmgl.h
+++ b/include/nmgl.h
@@ -62,4 +62,6 @@ void nmglViewport(NMGLint x, NMGLint y, NMGLsizei width, NMGLsizei height);
 void nmglTexImage2D(NMGLenum target, NMGLint level, 
 					NMGLint internalformat, NMGLsizei width, NMGLsizei height, 
 					NMGLint border, NMGLenum format, NMGLenum type, const void *data );
+void nmglTexCoordPointer (NMGLint size, NMGLenum type, NMGLsizei stride, const void *pointer);
+
 #endif

--- a/include/nmgltex_nm0.h
+++ b/include/nmgltex_nm0.h
@@ -1,8 +1,15 @@
 #ifndef __NMGLTEX_NM0_H__
 #define __NMGLTEX_NM0_H__
 
+#include "demo3d_common.h"
+#include "nmgltex_common.h"
 
 struct NMGL_Context_NM0_Texture {
+	
+	/**
+	* Массивы текстурных координат
+	*/
+	Array texcoordArray[NMGL_MAX_TEX_UNITS];
 	
 	/**
 	*  Имя активного текстурного модуля.
@@ -15,11 +22,33 @@ struct NMGL_Context_NM0_Texture {
 	*/
 	unsigned int activeTexUnitIndex;
 	
+	/**
+	*  Имя клиентского активного текстурного модуля.
+	*/
+	NMGLenum clientActiveTexUnit;
+
+	/**
+	*  Индекс клиентского активного текстурного модуля в массиве текстурных модулей.
+	*  Используется для доступа к клиентскому активному текстурному модулю
+	*/
+	unsigned int clientActiveTexUnitIndex;
+	
 	
 	void init(){
 	
 		activeTexUnit = NMGL_TEXTURE0;
 		activeTexUnitIndex = 0;
+		clientActiveTexUnit = NMGL_TEXTURE0;
+		clientActiveTexUnitIndex = 0;
+		
+		for (int i = 0; i < NMGL_MAX_TEX_UNITS; i++)
+		{
+			texcoordArray[i].pointer = 0;
+			texcoordArray[i].size = 4;
+			texcoordArray[i].stride = 0;
+			texcoordArray[i].type = NMGL_FLOAT;
+			texcoordArray[i].enabled = NMGL_FALSE;
+		}
 	}
 	
 };

--- a/include/nmgltex_nm0.h
+++ b/include/nmgltex_nm0.h
@@ -1,10 +1,6 @@
 #ifndef __NMGLTEX_NM0_H__
 #define __NMGLTEX_NM0_H__
 
-/*
-* Максимальное поддерживаемое количество текстурных модулей
-*/
-#define NMGL_MAX_TEX_UNITS 1 //TODO: Значение, возвращаемое при вызове функции glGetIntegeri с параметром NMGL_MAX_TEXTURE_UNITS
 
 struct NMGL_Context_NM0_Texture {
 	

--- a/src_proc0/nmgl/nmglDisableClientState.cpp
+++ b/src_proc0/nmgl/nmglDisableClientState.cpp
@@ -15,4 +15,7 @@ void nmglDisableClientState(NMGLenum array) {
 	if (array == NMGL_NORMAL_ARRAY) {
 		cntxt.normalArray.enabled = NMGL_FALSE;
 	}
+	if (array == NMGL_TEXTURE_COORD_ARRAY) {
+		cntxt.texState.texcoordArray[cntxt.texState.clientActiveTexUnitIndex].enabled = NMGL_FALSE;
+	}
 }

--- a/src_proc0/nmgl/nmglEnableClientState.cpp
+++ b/src_proc0/nmgl/nmglEnableClientState.cpp
@@ -16,4 +16,7 @@ void nmglEnableClientState(NMGLenum array) {
 	if (array == NMGL_NORMAL_ARRAY) {
 		cntxt.normalArray.enabled = NMGL_TRUE;
 	}
+	if (array == NMGL_TEXTURE_COORD_ARRAY) {
+		cntxt.texState.texcoordArray[cntxt.texState.clientActiveTexUnitIndex].enabled = NMGL_TRUE;
+	}
 }

--- a/src_proc0/nmgl/nmglTexCoordPointer.cpp
+++ b/src_proc0/nmgl/nmglTexCoordPointer.cpp
@@ -1,0 +1,27 @@
+#include "demo3d_nm0.h"
+#include "nmgl.h"
+#include "nmgl_data0.h"
+
+#pragma code_section ".text_nmgl"
+
+SECTION(".text_nmgl")
+void nmglTexCoordPointer (NMGLint size, NMGLenum type, NMGLsizei stride, const void *pointer)
+{
+	if ((size != 2) || (stride != 0) || (pointer == NULL))
+	{
+		cntxt.error = NMGL_INVALID_VALUE;
+		return;
+	}
+
+	if (type != NMGL_FLOAT)
+	{
+		cntxt.error = NMGL_INVALID_ENUM;
+		return;
+	}
+
+	cntxt.texState.texcoordArray[cntxt.texState.clientActiveTexUnitIndex].size = size;
+	cntxt.texState.texcoordArray[cntxt.texState.clientActiveTexUnitIndex].type = type;
+	cntxt.texState.texcoordArray[cntxt.texState.clientActiveTexUnitIndex].stride = stride;
+	cntxt.texState.texcoordArray[cntxt.texState.clientActiveTexUnitIndex].pointer = pointer;
+	
+}


### PR DESCRIPTION
Добавлена реализация функция nmglTexCoordPointer. Также в текстурный контекст nmpu0 добавлены необходимые для её работы поля: массив массивов текстурных координат, а также идентификатор массива текстурных координат. Спецификация не требует поддержки более одного массива текстурных координат (= текстурных модулей), но код написан с учётом возможности наличия нескольких текстурных модулей. На данный момент предполагается поддержка одного текстурного модуля и, следовательно, одного массива текстурных координат (NMGL_MAX_TEX_UNITS = 1). 