### PR TITLE
Change linker scripts: put text_demo3d section into IMU

### DIFF
--- a/test/perf/mai/make_mc12101_nmpu0-ld/mc12101board-nmpu0.ld
+++ b/test/perf/mai/make_mc12101_nmpu0-ld/mc12101board-nmpu0.ld
@@ -20,6 +20,10 @@ SECTIONS
   {
     *(.text);
   } > EMI
+  .text_demo3d : ALIGN(0x8)
+  {
+    *(.text_demo3d);
+  } > C0_IMU5
   .init : ALIGN(0x8)
   {
     *(.init);

--- a/test/perf/mai/make_mc12101_nmpu1-ld/mc12101board-nmpu1.ld
+++ b/test/perf/mai/make_mc12101_nmpu1-ld/mc12101board-nmpu1.ld
@@ -15,6 +15,10 @@ SECTIONS
   {
     *(.text);
   } > EMI
+  .text_demo3d : ALIGN(0x8)
+  {
+    *(.text);
+  } > C0_IMU0 
   .init : ALIGN(0x8)
   {
     *(.init);

--- a/test/perf/rcm/make_mc12101_nmpu0-ld/mc12101board-nmpu0.ld
+++ b/test/perf/rcm/make_mc12101_nmpu0-ld/mc12101board-nmpu0.ld
@@ -20,6 +20,10 @@ SECTIONS
   {
     *(.text);
   } > EMI
+  .text_demo3d : ALIGN(0x8)
+  {
+    *(.text_demo3d);
+  } > C0_IMU5
   .init : ALIGN(0x8)
   {
     *(.init);

--- a/test/perf/rcm/make_mc12101_nmpu1-ld/mc12101board-nmpu1.ld
+++ b/test/perf/rcm/make_mc12101_nmpu1-ld/mc12101board-nmpu1.ld
@@ -15,6 +15,10 @@ SECTIONS
   {
     *(.text);
   } > EMI
+  .text_demo3d : ALIGN(0x8)
+  {
+    *(.text);
+  } > C0_IMU0 
   .init : ALIGN(0x8)
   {
     *(.init);


### PR DESCRIPTION
Many functions are placed into text_demo3d section, but this section
is not defined in the linker script. This section should be placed into
the internal memory for faster execution.