### PR TITLE
Change testperf Makefile for mai and rcm

### DIFF
--- a/test/perf/mai/Makefile
+++ b/test/perf/mai/Makefile
@@ -1,13 +1,7 @@
 
 default: config_nmpu0
 	
-
-all: config_mc12101_0_gcc config_mc12101_1_gcc run outdir
-	
-
-
 run:
-
 
 all_mc12101: configure0 configure1
 	testperf run
@@ -24,7 +18,7 @@ run:
 	testperf run
 
 kill:
-	testperf kill
+	testperf del 
 
 outdir:
 	testperf outdir

--- a/test/perf/rcm/Makefile
+++ b/test/perf/rcm/Makefile
@@ -1,13 +1,7 @@
 
 default: config_nmpu0
 	
-
-all: config_mc12101_0_gcc config_mc12101_1_gcc run outdir
-	
-
-
 run:
-
 
 all_mc12101: configure0 configure1
 	testperf run
@@ -22,7 +16,7 @@ run:
 	testperf run
 
 kill:
-	testperf kill
+	testperf del
 
 outdir:
 	testperf outdir


### PR DESCRIPTION
Delete `all` target and change `testperf kill` to `testperf del`
because the current version of testperf uses del command to delete test folders