### PR TITLE
Add testperf scenarios for service functions

### DIFF
--- a/include/service.h
+++ b/include/service.h
@@ -16,8 +16,13 @@ typedef v4nm32u abgr32;
 \par
 \xmlonly
 	<testperf>
- 		<param name=" srcArray "> im0 im1 </param>
- 		<param name=" dstArray "> im2 im3 </param>
+ 		<param name=" srcArray "> im00 </param>
+ 		<param name=" dstArray "> im10 </param>
+ 		<param name=" count "> 0 4 8 12 16 20 24 28 32 36 40 128 256 512 </param>
+	</testperf>
+	<testperf>
+ 		<param name=" srcArray "> im00 im10 im20 im30 </param>
+ 		<param name=" dstArray "> im01 im11 im21 im31 </param>
  		<param name=" count "> 4 </param>
 	</testperf>
 \endxmlonly
@@ -36,8 +41,13 @@ extern "C" void convertABGR32_RGB565(const abgr32  *srcArray, rgb565 *dstArray, 
 \par
 \xmlonly
 	<testperf>
- 		<param name=" srcArray "> im0 im1 </param>
- 		<param name=" dstArray "> im2 im3 </param>
+ 		<param name=" srcArray "> im00 </param>
+ 		<param name=" dstArray "> im10 </param>
+ 		<param name=" count "> 0 4 8 16 20 24 28 32 36 40 128 256 512 1024 2048 4096 </param>
+	</testperf>
+	<testperf>
+ 		<param name=" srcArray "> im00 im10 im20 im30 </param>
+ 		<param name=" dstArray "> im01 im11 im21 im31 </param>
  		<param name=" count "> 4 </param>
 	</testperf>
 \endxmlonly
@@ -59,28 +69,52 @@ extern "C" void convertRGB565_RGB8888(const rgb565 *srcArray, rgb8888 *dstArray,
 \par
 \xmlonly
 	<testperf>
- 		<param name=" srcVertex "> im0 </param>
- 		<param name=" srcColor "> im0 </param>
- 		<param name=" dstVertex "> im0 </param>
- 		<param name=" dstColor "> im0 </param>
+ 		<param name=" srcVertex "> im00 </param>
+ 		<param name=" srcColor ">  im10 </param>
+ 		<param name=" dstVertex "> im20 </param>
+ 		<param name=" dstColor ">  im30 </param>
  		<param name=" mode "> NMGL_TRIANGLES </param>
- 		<param name=" vertCount "> 192 48 </param>
+ 		<param name=" vertCount "> 0 48 96 192 384 </param>
 	</testperf>
 	<testperf>
- 		<param name=" srcVertex "> im0 </param>
- 		<param name=" srcColor "> im0 </param>
- 		<param name=" dstVertex "> im0 </param>
- 		<param name=" dstColor "> im0 </param>
+ 		<param name=" srcVertex "> im00 </param>
+ 		<param name=" srcColor ">  im10 </param>
+ 		<param name=" dstVertex "> im20 </param>
+ 		<param name=" dstColor ">  im30 </param>
  		<param name=" mode "> NMGL_TRIANGLE_STRIP </param>
- 		<param name=" vertCount "> 66 34 </param>
+ 		<param name=" vertCount "> 0 34 66 136 264 </param>
 	</testperf>
 	<testperf>
- 		<param name=" srcVertex "> im0 </param>
- 		<param name=" srcColor "> im0 </param>
- 		<param name=" dstVertex "> im0 </param>
- 		<param name=" dstColor "> im0 </param>
+ 		<param name=" srcVertex "> im00 </param>
+ 		<param name=" srcColor ">  im10 </param>
+ 		<param name=" dstVertex "> im20 </param>
+ 		<param name=" dstColor ">  im30 </param>
  		<param name=" mode "> NMGL_TRIANGLE_FAN </param>
- 		<param name=" vertCount "> 66 34 </param>
+ 		<param name=" vertCount "> 0 34 66 136 264 </param>
+	</testperf>
+	<testperf>
+ 		<param name=" srcVertex "> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+ 		<param name=" srcColor ">  im01 im11 im21 im31 im41 im51 im61 im71 </param>
+ 		<param name=" dstVertex "> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+ 		<param name=" dstColor ">  im03 im13 im23 im33 im43 im53 im63 im73 </param>
+ 		<param name=" mode "> NMGL_TRIANGLES </param>
+ 		<param name=" vertCount "> 48 96 </param>
+	</testperf>
+	<testperf>
+ 		<param name=" srcVertex "> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+ 		<param name=" srcColor ">  im01 im11 im21 im31 im41 im51 im61 im71 </param>
+ 		<param name=" dstVertex "> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+ 		<param name=" dstColor ">  im03 im13 im23 im33 im43 im53 im63 im73 </param>
+ 		<param name=" mode "> NMGL_TRIANGLE_STRIP </param>
+ 		<param name=" vertCount "> 34 66 </param>
+	</testperf>
+	<testperf>
+ 		<param name=" srcVertex "> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+ 		<param name=" srcColor ">  im01 im11 im21 im31 im41 im51 im61 im71 </param>
+ 		<param name=" dstVertex "> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+ 		<param name=" dstColor ">  im03 im13 im23 im33 im43 im53 im63 im73 </param>
+ 		<param name=" mode "> NMGL_TRIANGLE_FAN </param>
+ 		<param name=" vertCount "> 34 66 </param>
 	</testperf>
 \endxmlonly
 */
@@ -101,10 +135,17 @@ extern "C" int vertexPrimitiveRepack(const v4nm32f *srcVertex, const v4nm32f *sr
 \par
 \xmlonly
 	<testperf>
- 		<param name=" srcArray "> im0 im1 im2 im3 im4 im5 </param>
- 		<param name=" wArray "> im1 im2 im3 im4 im5 </param>
- 		<param name=" evenFlags "> im1 im2 im3 im4 im5 </param>
- 		<param name=" oddFlags "> im1 im2 im3 im4 im5 </param>
+ 		<param name=" srcArray ">	im00 </param>
+ 		<param name=" wArray ">		im10 </param>
+ 		<param name=" evenFlags ">	im20 </param>
+ 		<param name=" oddFlags ">	im30 </param>
+ 		<param name=" size "> 0 64 128 192 256 512 768 1024 1280 1536 1792 2048 </param>
+	</testperf>
+	<testperf>
+ 		<param name=" srcArray ">	im00 im10 im20 im30 im40 im50 im60 im70 </param>
+ 		<param name=" wArray ">		im01 im11 im21 im31 im41 im51 im61 im71 </param>
+ 		<param name=" evenFlags ">	im02 im12 im22 im32 im42 im52 im62 im72 </param>
+ 		<param name=" oddFlags ">	im03 im13 im23 im33 im43 im53 im63 im73 </param>
  		<param name=" size "> 64 </param>
 	</testperf>
 \endxmlonly
@@ -199,9 +240,11 @@ static void srcVertexInit(nm32f *srcVertex, int srcCount)
 							};
 
 	int coordCount = 9 * srcCount;
-
-	for (int i = 0; i < coordCount; ++i){
-		srcVertex[i] = srcVertexInitArray[i];
+	// Put srcCount similar triangles into srcVertex
+	for (int i = 0; i < srcCount; ++i){
+		for (int j = 0; j < coordCount; ++j){
+			srcVertex[9 * i + j] = srcVertexInitArray[j];
+		}
 	}
 }
 
@@ -221,15 +264,45 @@ static void srcVertexInit(nm32f *srcVertex, int srcCount)
 \par
 \xmlonly
 	<testperf>
- 		<param name=" srcVertex "> im0 </param>
- 		<param name=" srcColor "> im1 </param>
+ 		<param name=" srcVertex "> im00 </param>
+ 		<param name=" srcColor "> im10 </param>
+ 		<param name=" srcCount "> 0 1 2 3 4 5 6 8 8 9 10 11 12 13 14 15 16 17 18 19 20 </param>
+ 		<param name=" maxWidth "> 2 </param>
+ 		<param name=" maxHeight "> 2 </param>
+ 		<param name=" maxDstSize "> 10 </param>
+ 		<param name=" dstVertex "> im20 </param>
+ 		<param name=" dstColor "> im30 </param>
+ 		<param name=" srcTreatedCount "> im0 </param>
+		<init>
+			srcVertexInit(srcVertex, 20);
+		</init>
+		<size> srcCount </size>
+	</testperf>
+	<testperf>
+ 		<param name=" srcVertex "> im00 </param>
+ 		<param name=" srcColor "> im10 </param>
+ 		<param name=" srcCount "> 0 1 2 3 4 5 6 8 8 9 10 11 12 13 14 15 16 17 18 19 20 </param>
+ 		<param name=" maxWidth "> 1 </param>
+ 		<param name=" maxHeight "> 1 </param>
+ 		<param name=" maxDstSize "> 10 </param>
+ 		<param name=" dstVertex "> im20 </param>
+ 		<param name=" dstColor "> im30 </param>
+ 		<param name=" srcTreatedCount "> im0 </param>
+		<init>
+			srcVertexInit(srcVertex, 20);
+		</init>
+		<size> srcCount </size>
+	</testperf>
+	<testperf>
+ 		<param name=" srcVertex "> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+ 		<param name=" srcColor "> im01 im11 im21 im31 im41 im51 im61 im71 </param>
  		<param name=" srcCount "> 1 </param>
  		<param name=" maxWidth "> 1 </param>
  		<param name=" maxHeight "> 1 </param>
  		<param name=" maxDstSize "> 10 </param>
- 		<param name=" dstVertex "> im2 </param>
- 		<param name=" dstColor "> im3 </param>
- 		<param name=" srcTreatedCount "> im4 </param>
+ 		<param name=" dstVertex "> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+ 		<param name=" dstColor "> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+ 		<param name=" srcTreatedCount "> im0 im1 im2 im3 im4 im5 im6 im7 </param>
 		<init>
 			srcVertexInit(srcVertex, 1);
 		</init>

--- a/test/perf/mai/make_mc12101_nmpu0-ld/main.cpp
+++ b/test/perf/mai/make_mc12101_nmpu0-ld/main.cpp
@@ -6,16 +6,51 @@
 #include "demo3d_nm0.h"
 #include "service.h"
 
-__attribute__((section(".mem_bank0"))) long long im0[2048];
-__attribute__((section(".mem_bank1"))) long long im1[2048];
-__attribute__((section(".mem_bank2"))) long long im2[2048];
-__attribute__((section(".mem_bank3"))) long long im3[2048];
-__attribute__((section(".mem_bank4"))) long long im4[2048];
-__attribute__((section(".mem_bank5"))) long long im5[2048];
-//__attribute__((section(".mem_bank6"))) long long im6[2048];
-//__attribute__((section(".mem_bank7"))) long long im7[2048];
+__attribute__((section(".mem_bank0"))) long long im0[1];
+__attribute__((section(".mem_bank1"))) long long im1[1];
+__attribute__((section(".mem_bank2"))) long long im2[1];
+__attribute__((section(".mem_bank3"))) long long im3[1];
+__attribute__((section(".mem_bank4"))) long long im4[1];
+__attribute__((section(".mem_bank5"))) long long im5[1];
+__attribute__((section(".mem_bank6"))) long long im6[1];
+__attribute__((section(".mem_bank7"))) long long im7[1];
+__attribute__((section(".mem_bank0"))) long long im00[2048];
+__attribute__((section(".mem_bank0"))) long long im01[2048];
+__attribute__((section(".mem_bank0"))) long long im02[2048];
+__attribute__((section(".mem_bank0"))) long long im03[2048];
+__attribute__((section(".mem_bank1"))) long long im10[2048];
+__attribute__((section(".mem_bank1"))) long long im11[2048];
+__attribute__((section(".mem_bank1"))) long long im12[2048];
+__attribute__((section(".mem_bank1"))) long long im13[2048];
+__attribute__((section(".mem_bank2"))) long long im20[2048];
+__attribute__((section(".mem_bank2"))) long long im21[2048];
+__attribute__((section(".mem_bank2"))) long long im22[2048];
+__attribute__((section(".mem_bank2"))) long long im23[2048];
+__attribute__((section(".mem_bank3"))) long long im30[2048];
+__attribute__((section(".mem_bank3"))) long long im31[2048];
+__attribute__((section(".mem_bank3"))) long long im32[2048];
+__attribute__((section(".mem_bank3"))) long long im33[2048];
+__attribute__((section(".mem_bank4"))) long long im40[2048];
+__attribute__((section(".mem_bank4"))) long long im41[2048];
+__attribute__((section(".mem_bank4"))) long long im42[2048];
+__attribute__((section(".mem_bank4"))) long long im43[2048];
+__attribute__((section(".mem_bank5"))) long long im50[2048];
+__attribute__((section(".mem_bank5"))) long long im51[2048];
+__attribute__((section(".mem_bank5"))) long long im52[2048];
+__attribute__((section(".mem_bank5"))) long long im53[2048];
+__attribute__((section(".mem_bank6"))) long long im60[2048];
+__attribute__((section(".mem_bank6"))) long long im61[2048];
+__attribute__((section(".mem_bank6"))) long long im62[2048];
+__attribute__((section(".mem_bank6"))) long long im63[2048];
+__attribute__((section(".mem_bank7"))) long long im70[2048];
+__attribute__((section(".mem_bank7"))) long long im71[2048];
+__attribute__((section(".mem_bank7"))) long long im72[2048];
+__attribute__((section(".mem_bank7"))) long long im73[2048];
 
-__attribute__((section(".data_DDR"))) long long emi[4096];
+__attribute__((section(".data_DDR"))) long long emi0[4096];
+__attribute__((section(".data_DDR"))) long long emi1[4096];
+__attribute__((section(".data_DDR"))) long long emi2[4096];
+__attribute__((section(".data_DDR"))) long long emi3[4096];
 
 
 int main()

--- a/test/perf/mai/make_mc12101_nmpu1-ld/main.cpp
+++ b/test/perf/mai/make_mc12101_nmpu1-ld/main.cpp
@@ -6,17 +6,18 @@
 #include "demo3d_nm1.h"
 #include "service.h"
 
-__attribute__((section(".mem_bank0"))) long long im0[2048];
-__attribute__((section(".mem_bank1"))) long long im1[2048];
-__attribute__((section(".mem_bank2"))) long long im2[2048];
-__attribute__((section(".mem_bank3"))) long long im3[2048];
-//__attribute__((section(".mem_bank4"))) long long im4[2048];
-//__attribute__((section(".mem_bank5"))) long long im5[2048];
-//__attribute__((section(".mem_bank6"))) long long im6[2048];
-//__attribute__((section(".mem_bank7"))) long long im7[2048];
+__attribute__((section(".mem_bank0"))) long long im00[2048];
+__attribute__((section(".mem_bank0"))) long long im01[2048];
+__attribute__((section(".mem_bank1"))) long long im10[2048];
+__attribute__((section(".mem_bank1"))) long long im11[2048];
+__attribute__((section(".mem_bank1"))) long long im13[2048];
+__attribute__((section(".mem_bank2"))) long long im20[2048];
+__attribute__((section(".mem_bank2"))) long long im21[2048];
+__attribute__((section(".mem_bank3"))) long long im30[2048];
+__attribute__((section(".mem_bank3"))) long long im31[2048];
 
-__attribute__((section(".data_DDR"))) long long emi[4096];
-
+__attribute__((section(".data_DDR"))) long long emi0[4096];
+__attribute__((section(".data_DDR"))) long long emi1[4096];
 
 int main()
 {


### PR DESCRIPTION
Add test description to service.h and arrays to corresponding main files
of nmpu0 and nmpu1 test/perf/mai projects.
There are no DDR option in test scenarios (there are arrays in main.cpp files )
because it is slow than internal memory and the performance will be low when
data are in DDR. In order to use DDR arrays add emi_ij array to corresponding
parameter of test scenario. There are four DDR arrays for nmpu0 and two arrays -
for nmpu1.

NOTE:
This commit uses modified vertexPrimitiveRepack.cpp file instead of
.asm. Tests work but rename .cpp to ._cpp and ._asm to .asm in src_proc0/nm to
build the right version of vertexPrimitiveRepack function.