### PR TITLE
Fix service perf tests

### DIFF
--- a/include/service.h
+++ b/include/service.h
@@ -19,7 +19,7 @@ typedef v4nm32u abgr32;
 	<testperf>
  		<param name=" srcArray "> im00 </param>
  		<param name=" dstArray "> im10 </param>
- 		<param name=" count "> 0 4 8 12 16 20 24 28 32 36 40 128 256 512 </param>
+ 		<param name=" count "> 4 8 12 16 20 24 28 32 36 40 128 256 512 </param>
 	</testperf>
 	<testperf>
  		<param name=" srcArray "> im00 im10 im20 im30 </param>
@@ -44,7 +44,7 @@ extern "C" void convertABGR32_RGB565(const abgr32  *srcArray, rgb565 *dstArray, 
 	<testperf>
  		<param name=" srcArray "> im00 </param>
  		<param name=" dstArray "> im10 </param>
- 		<param name=" count "> 0 4 8 16 20 24 28 32 36 40 128 256 512 1024 2048 4096 </param>
+ 		<param name=" count "> 4 8 16 20 24 28 32 36 40 128 256 512 1024 2048 4096 </param>
 	</testperf>
 	<testperf>
  		<param name=" srcArray "> im00 im10 im20 im30 </param>
@@ -75,7 +75,7 @@ extern "C" void convertRGB565_RGB8888(const rgb565 *srcArray, rgb8888 *dstArray,
  		<param name=" dstVertex "> im20 </param>
  		<param name=" dstColor ">  im30 </param>
  		<param name=" mode "> NMGL_TRIANGLES </param>
- 		<param name=" vertCount "> 0 48 96 192 384 </param>
+ 		<param name=" vertCount "> 48 96 192 384 </param>
 	</testperf>
 	<testperf>
  		<param name=" srcVertex "> im00 </param>
@@ -83,7 +83,7 @@ extern "C" void convertRGB565_RGB8888(const rgb565 *srcArray, rgb8888 *dstArray,
  		<param name=" dstVertex "> im20 </param>
  		<param name=" dstColor ">  im30 </param>
  		<param name=" mode "> NMGL_TRIANGLE_STRIP </param>
- 		<param name=" vertCount "> 0 34 66 136 264 </param>
+ 		<param name=" vertCount "> 34 66 136 264 </param>
 	</testperf>
 	<testperf>
  		<param name=" srcVertex "> im00 </param>
@@ -91,7 +91,7 @@ extern "C" void convertRGB565_RGB8888(const rgb565 *srcArray, rgb8888 *dstArray,
  		<param name=" dstVertex "> im20 </param>
  		<param name=" dstColor ">  im30 </param>
  		<param name=" mode "> NMGL_TRIANGLE_FAN </param>
- 		<param name=" vertCount "> 0 34 66 136 264 </param>
+ 		<param name=" vertCount "> 34 66 136 264 </param>
 	</testperf>
 	<testperf>
  		<param name=" srcVertex "> im00 im10 im20 im30 im40 im50 im60 im70 </param>
@@ -140,7 +140,7 @@ extern "C" int vertexPrimitiveRepack(const v4nm32f *srcVertex, const v4nm32f *sr
  		<param name=" wArray ">		im10 </param>
  		<param name=" evenFlags ">	im20 </param>
  		<param name=" oddFlags ">	im30 </param>
- 		<param name=" size "> 0 64 128 192 256 512 768 1024 1280 1536 1792 2048 </param>
+ 		<param name=" size "> 64 128 192 256 512 768 1024 1280 1536 1792 2048 </param>
 	</testperf>
 	<testperf>
  		<param name=" srcArray ">	im00 im10 im20 im30 im40 im50 im60 im70 </param>
@@ -274,7 +274,7 @@ static void srcVertexInit(nm32f *srcVertex, int srcCount)
 	<testperf>
  		<param name=" srcVertex "> im00 </param>
  		<param name=" srcColor "> im10 </param>
- 		<param name=" srcCount "> 0 1 2 3 4 5 6 8 8 9 10 11 12 13 14 15 16 17 18 19 20 </param>
+ 		<param name=" srcCount "> 1 2 3 4 5 6 8 8 9 10 11 12 13 14 15 16 17 18 19 20 </param>
  		<param name=" maxWidth "> 2 </param>
  		<param name=" maxHeight "> 2 </param>
  		<param name=" maxDstSize "> 10 </param>
@@ -289,7 +289,7 @@ static void srcVertexInit(nm32f *srcVertex, int srcCount)
 	<testperf>
  		<param name=" srcVertex "> im00 </param>
  		<param name=" srcColor "> im10 </param>
- 		<param name=" srcCount "> 0 1 2 3 4 5 6 8 8 9 10 11 12 13 14 15 16 17 18 19 20 </param>
+ 		<param name=" srcCount "> 1 2 3 4 5 6 8 8 9 10 11 12 13 14 15 16 17 18 19 20 </param>
  		<param name=" maxWidth "> 1 </param>
  		<param name=" maxHeight "> 1 </param>
  		<param name=" maxDstSize "> 10 </param>

--- a/test/perf/mai/make_mc12101_nmpu0-ld/main.cpp
+++ b/test/perf/mai/make_mc12101_nmpu0-ld/main.cpp
@@ -6,16 +6,51 @@
 #include "demo3d_nm0.h"
 #include "service.h"
 
-__attribute__((section(".mem_bank0"))) long long im0[2048];
-__attribute__((section(".mem_bank1"))) long long im1[2048];
-__attribute__((section(".mem_bank2"))) long long im2[2048];
-__attribute__((section(".mem_bank3"))) long long im3[2048];
-__attribute__((section(".mem_bank4"))) long long im4[2048];
-__attribute__((section(".mem_bank5"))) long long im5[2048];
-//__attribute__((section(".mem_bank6"))) long long im6[2048];
-//__attribute__((section(".mem_bank7"))) long long im7[2048];
+__attribute__((section(".mem_bank0"))) long long im0[1];
+__attribute__((section(".mem_bank1"))) long long im1[1];
+__attribute__((section(".mem_bank2"))) long long im2[1];
+__attribute__((section(".mem_bank3"))) long long im3[1];
+__attribute__((section(".mem_bank4"))) long long im4[1];
+__attribute__((section(".mem_bank5"))) long long im5[1];
+__attribute__((section(".mem_bank6"))) long long im6[1];
+__attribute__((section(".mem_bank7"))) long long im7[1];
+__attribute__((section(".mem_bank0"))) long long im00[2048];
+__attribute__((section(".mem_bank0"))) long long im01[2048];
+__attribute__((section(".mem_bank0"))) long long im02[2048];
+__attribute__((section(".mem_bank0"))) long long im03[2048];
+__attribute__((section(".mem_bank1"))) long long im10[2048];
+__attribute__((section(".mem_bank1"))) long long im11[2048];
+__attribute__((section(".mem_bank1"))) long long im12[2048];
+__attribute__((section(".mem_bank1"))) long long im13[2048];
+__attribute__((section(".mem_bank2"))) long long im20[2048];
+__attribute__((section(".mem_bank2"))) long long im21[2048];
+__attribute__((section(".mem_bank2"))) long long im22[2048];
+__attribute__((section(".mem_bank2"))) long long im23[2048];
+__attribute__((section(".mem_bank3"))) long long im30[2048];
+__attribute__((section(".mem_bank3"))) long long im31[2048];
+__attribute__((section(".mem_bank3"))) long long im32[2048];
+__attribute__((section(".mem_bank3"))) long long im33[2048];
+__attribute__((section(".mem_bank4"))) long long im40[2048];
+__attribute__((section(".mem_bank4"))) long long im41[2048];
+__attribute__((section(".mem_bank4"))) long long im42[2048];
+__attribute__((section(".mem_bank4"))) long long im43[2048];
+__attribute__((section(".mem_bank5"))) long long im50[2048];
+__attribute__((section(".mem_bank5"))) long long im51[2048];
+__attribute__((section(".mem_bank5"))) long long im52[2048];
+__attribute__((section(".mem_bank5"))) long long im53[2048];
+__attribute__((section(".mem_bank6"))) long long im60[2048];
+__attribute__((section(".mem_bank6"))) long long im61[2048];
+__attribute__((section(".mem_bank6"))) long long im62[2048];
+__attribute__((section(".mem_bank6"))) long long im63[2048];
+__attribute__((section(".mem_bank7"))) long long im70[2048];
+__attribute__((section(".mem_bank7"))) long long im71[2048];
+__attribute__((section(".mem_bank7"))) long long im72[2048];
+__attribute__((section(".mem_bank7"))) long long im73[2048];
 
-__attribute__((section(".data_DDR"))) long long emi[4096];
+__attribute__((section(".data_DDR"))) long long emi0[4096];
+__attribute__((section(".data_DDR"))) long long emi1[4096];
+__attribute__((section(".data_DDR"))) long long emi2[4096];
+__attribute__((section(".data_DDR"))) long long emi3[4096];
 
 
 int main()

--- a/test/perf/mai/make_mc12101_nmpu1-ld/main.cpp
+++ b/test/perf/mai/make_mc12101_nmpu1-ld/main.cpp
@@ -6,17 +6,18 @@
 #include "demo3d_nm1.h"
 #include "service.h"
 
-__attribute__((section(".mem_bank0"))) long long im0[2048];
-__attribute__((section(".mem_bank1"))) long long im1[2048];
-__attribute__((section(".mem_bank2"))) long long im2[2048];
-__attribute__((section(".mem_bank3"))) long long im3[2048];
-//__attribute__((section(".mem_bank4"))) long long im4[2048];
-//__attribute__((section(".mem_bank5"))) long long im5[2048];
-//__attribute__((section(".mem_bank6"))) long long im6[2048];
-//__attribute__((section(".mem_bank7"))) long long im7[2048];
+__attribute__((section(".mem_bank0"))) long long im00[2048];
+__attribute__((section(".mem_bank0"))) long long im01[2048];
+__attribute__((section(".mem_bank1"))) long long im10[2048];
+__attribute__((section(".mem_bank1"))) long long im11[2048];
+__attribute__((section(".mem_bank1"))) long long im13[2048];
+__attribute__((section(".mem_bank2"))) long long im20[2048];
+__attribute__((section(".mem_bank2"))) long long im21[2048];
+__attribute__((section(".mem_bank3"))) long long im30[2048];
+__attribute__((section(".mem_bank3"))) long long im31[2048];
 
-__attribute__((section(".data_DDR"))) long long emi[4096];
-
+__attribute__((section(".data_DDR"))) long long emi0[4096];
+__attribute__((section(".data_DDR"))) long long emi1[4096];
 
 int main()
 {


### PR DESCRIPTION
Delete zero inputs in testperf scenarios.
Update main.cpp in test/perf/mai (forgot about it earlier) before merging combine into textures. Textures already has this templates updated, but combine doesn't