### PR TITLE
Shift libnmopengl left in Makefile for tests

### DIFF
--- a/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
@@ -61,7 +61,7 @@ CC 				 = nmc-g++
 AS               = nmc-gcc 				 
 AS_FLAGS    	 = -c -mmas -x assembler -Wa,-split_sir -mnmc4-float
 CC_FLAGS		 = -std=c++11
-LIBS             = -lnmpp-nmc4f -lhal-mc12101 -lnmopengl-nmc4f
+LIBS             = -lnmopengl-nmc4f -lnmpp-nmc4f -lhal-mc12101 
 LINKER_FLAGS     =   -Xlinker -Map=.main0.map $(LIB_DIRS) "-Wl,-cmc12101brd-nmpu0.cfg"  -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o$(TARGET)
 #=================== SOURCE & OBJECTS COLLECTION ===========================
 

--- a/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
@@ -62,7 +62,7 @@ CC 				 = nmc-g++
 AS               = nmc-gcc 				 
 AS_FLAGS    	 = -c -mmas -x assembler -Wa,-split_sir -mnmc4-fixed
 CC_FLAGS		 = -std=c++11
-LIBS             = -lnmpp-nmc4 -lhal-mc12101 -lnmopengl-nmc4
+LIBS             = -lnmopengl-nmc4 -lnmpp-nmc4 -lhal-mc12101 
 LINKER_FLAGS     =   -Xlinker -Map=.main1.map $(LIB_DIRS) "-Wl,-cmc12101brd-nmpu1.cfg"  -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o$(TARGET)
 #=================== SOURCE & OBJECTS COLLECTION ===========================
 

--- a/app/templates/sometest/make_x86/premake5.lua
+++ b/app/templates/sometest/make_x86/premake5.lua
@@ -7,7 +7,7 @@
       kind "ConsoleApp"
       language "C++"
       files { "../*.cpp", "../../../../src_proc0/pc/*.cpp","../../../../src_proc0/pc/*.c","../../../../src_proc1/pc/*.cpp", "../../../../src_proc1/pc/*.c" }
-	  links { "nmpp-x86.lib", "hal-virtual-x86.lib", "tinyxml.lib", "nmopengl-x86.lib" }
+	  links { "nmopengl-x86.lib", "nmpp-x86.lib", "hal-virtual-x86.lib", "tinyxml.lib" }
 	  libdirs { "$(NMPP)/lib", "$(HAL)/lib", "$(TINYXML)", "../../../../lib"}
 	  includedirs { "../../../../include", "$(NMPP)/include", "$(HAL)/include", "$(TINYXML)"}
 


### PR DESCRIPTION
При сборке теста появлялась ошибка undefined reference, если в тесте используется функция из nmOpenGL, которая использует функции из nmpp или hal. Для исправления в шаблонах в Make-файлах тестов библиотека nmopengl  перемещена в начало списка библиотек для линковки (для x86, nmpu0_gcc, nmpu1_gcc).