### PR TITLE
Fix nmgltex_tests x86 build & 'make run' for debug x86 apps

### DIFF
--- a/2nmc-demo-gcc-example/make_x86/Makefile
+++ b/2nmc-demo-gcc-example/make_x86/Makefile
@@ -13,6 +13,12 @@ TARGET0   = demo3d-target0
 TARGET1   = demo3d-target1
 HOST      = demo3d-host
 
+ifeq ($(CONFIGURATION),Debug)
+	TARGET_SUFFIX = d
+else
+	TARGET_SUFFIX = 
+endif
+
 VS ?=vs2015
 ALL: $(VS)
 .PHONY = vs2005 vs2015
@@ -45,13 +51,13 @@ run:
 	$(MAKE) -j4 runhost runtarget0  runtarget1 
 
 runhost: $(HOST)
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget0: $(TARGET0) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget1: $(TARGET1) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 
 include $(ROOT)/clean.mk

--- a/2nmc-demo-gcc/make_x86/Makefile
+++ b/2nmc-demo-gcc/make_x86/Makefile
@@ -13,6 +13,12 @@ TARGET0   = demo3d-target0
 TARGET1   = demo3d-target1
 HOST      = demo3d-host
 
+ifeq ($(CONFIGURATION),Debug)
+	TARGET_SUFFIX = d
+else
+	TARGET_SUFFIX = 
+endif
+
 VS ?=vs2015
 ALL: $(VS)
 .PHONY = vs2005 vs2015
@@ -45,13 +51,13 @@ run:
 	$(MAKE) -j4 runhost runtarget0  runtarget1 
 
 runhost: $(HOST)
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget0: $(TARGET0) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget1: $(TARGET1) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 
 include $(ROOT)/clean.mk

--- a/app/nmgltex_tests/make_x86/Makefile
+++ b/app/nmgltex_tests/make_x86/Makefile
@@ -6,19 +6,28 @@ include $(ROOT)/global.mk
 
 .SUFFIXES:
 
+PLATFORM  ?= x64
+CONFIGURATION  ?= Release
 
-TARGET0   = demo3d-target0-x86
-TARGET1   = demo3d-target1-x86
-HOST      = demo3d-host-x86
+TARGET0   = demo3d-target0
+TARGET1   = demo3d-target1
+HOST      = demo3d-host
+
+ifeq ($(CONFIGURATION),Debug)
+	TARGET_SUFFIX = d
+else
+	TARGET_SUFFIX = 
+endif
 
 VS ?=vs2015
 ALL: $(VS)
 .PHONY = vs2005 vs2015
 
 debug: $(HOST).vcxproj $(TARGET0).vcxproj $(TARGET1).vcxproj
-	"$(VS140COMNTOOLS)vsvars32" && msbuild $(HOST).vcxproj    /p:Configuration=Debug
-	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET0).vcxproj /p:Configuration=Debug
-	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET1).vcxproj /p:Configuration=Debug
+	"$(VS140COMNTOOLS)vsvars32" && msbuild $(HOST).vcxproj    /p:Configuration=Debug /p:Platform=$(PLATFORM)
+	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET0).vcxproj /p:Configuration=Debug /p:Platform=$(PLATFORM)
+	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET1).vcxproj /p:Configuration=Debug /p:Platform=$(PLATFORM)
+
 $(TARGET0) $(TARGET1) $(HOST): $(VS)
 	
 vs2005: $(HOST).vcproj $(TARGET0).vcproj $(TARGET1).vcproj
@@ -28,9 +37,12 @@ vs2005: $(HOST).vcproj $(TARGET0).vcproj $(TARGET1).vcproj
 	
 
 vs2015:	$(HOST).vcxproj $(TARGET0).vcxproj $(TARGET1).vcxproj
-	"$(VS140COMNTOOLS)vsvars32" && msbuild $(HOST).vcxproj    /p:Configuration=Release
-	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET0).vcxproj /p:Configuration=Release
-	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET1).vcxproj /p:Configuration=Release
+	"$(VS140COMNTOOLS)vsvars32" && msbuild $(HOST).vcxproj    /p:Configuration=$(CONFIGURATION)    /p:Platform=$(PLATFORM)
+	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET0).vcxproj /p:Configuration=$(CONFIGURATION)    /p:Platform=$(PLATFORM)
+	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET1).vcxproj /p:Configuration=$(CONFIGURATION)    /p:Platform=$(PLATFORM)
+#	"$(VS140COMNTOOLS)vsvars32" && msbuild $(HOST).vcxproj    /p:Configuration=Release    /p:Platform=$(PLATFORM)
+#	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET0).vcxproj /p:Configuration=Release    /p:Platform=$(PLATFORM)
+#	"$(VS140COMNTOOLS)vsvars32" && msbuild $(TARGET1).vcxproj /p:Configuration=Release    /p:Platform=$(PLATFORM)
 
 $(HOST).vcproj $(TARGET0).vcproj $(TARGET1).vcproj:
 	premake5 vs2005
@@ -39,28 +51,29 @@ $(HOST).vcxproj $(TARGET0).vcxproj $(TARGET1).vcxproj:
 	premake5 vs2015
 
 
-run: 
+run: $(HOST) $(TARGET0) $(TARGET1)
 	$(MAKE) -j4 runhost runtarget0  runtarget1 
+	
 drun: 
 	$(MAKE) -j4 runhostd runtarget0d  runtarget1d 
-
+	
 runhost: $(HOST)
-	bin\Release\$(HOST)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget0: $(TARGET0) 
-	bin\Release\$(TARGET0)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget1: $(TARGET1) 
-	bin\Release\$(TARGET1)
-
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)$(TARGET_SUFFIX)
+	
 runhostd: $(HOST)
-	bin\debug\$(HOST)
+	bin\$(PLATFORM)\debug\$(HOST)-$(PLATFORM)d
 	
 runtarget0d: $(TARGET0) 
-	bin\debug\$(TARGET0)
+	bin\$(PLATFORM)\debug\$(TARGET0)-$(PLATFORM)d
 	
 runtarget1d: $(TARGET1) 
-	bin\debug\$(TARGET1)
+	bin\$(PLATFORM)\debug\$(TARGET1)-$(PLATFORM)d
 	
 libs:
 	

--- a/app/nmgltex_tests/make_x86/premake5.lua
+++ b/app/nmgltex_tests/make_x86/premake5.lua
@@ -1,73 +1,116 @@
 #!lua
 
 -- A solution contains projects, and defines the available configurations
-solution "demo3d-host-x86"
+solution "demo3d-host"
    configurations { "Debug", "Release" }
+   platforms{"x64", "x86"}
    -- A project defines one build target
-   project "demo3d-host-x86"
+   
+   project "demo3d-host"
 		kind "ConsoleApp"
 		language "C++"
 		files { "../../../include/*.h","../src_host/*.cpp","../src_host/*.c", "../../../nmglvs_mc12101-gcc/src_host/*.cpp"}
 		libdirs { "$(VSHELL)/lib","$(NMPP)/lib","$(HAL)/lib"}
 		includedirs { "$(MC12101)/include","$(HAL)/include","$(VSHELL)/include","$(NMPP)/include","../../../include"}
-		links { "vshell.lib","nmpp-x86.lib","hal-virtual-x86.lib"}
-
-      configuration "Debug"
-         defines { "DEBUG" }
-         symbols  "On" 
-
-      configuration "Release"
-         defines { "NDEBUG" }
-         symbols  "Off" 
+        configuration {"Debug","x86"}
+			links { "vshell.lib", "nmpp-x86d.lib","hal-virtual-x86d.lib"}
+			targetsuffix ("-x86d")
+			architecture "x32"
+			defines { "DEBUG", "EMULATION"}
+			symbols  "On" 
+		configuration {"Release","x86"}
+			links { "vshell.lib", "nmpp-x86.lib","hal-virtual-x86.lib"}
+			targetsuffix ("-x86")
+			architecture "x32"
+			defines { "NDEBUG", "EMULATION"}
+			symbols  "Off" 
+		configuration {"Debug","x64"}
+			links { "vshell.lib", "nmpp-x64d.lib","hal-virtual-x64d.lib"}
+			targetsuffix ("-x64d")
+			architecture "x64"
+			defines { "DEBUG", "EMULATION"}
+			symbols  "On" 
+		configuration {"Release","x64"}
+			links { "vshell.lib", "nmpp-x64.lib","hal-virtual-x64.lib"}
+			targetsuffix ("-x64")
+			architecture "x64"
+			defines { "NDEBUG", "EMULATION"}
+			symbols  "Off" 
 		 
 		 
 		 
-solution "demo3d-target0-x86"
+solution "demo3d-target0"
    configurations { "Debug", "Release" }
-   --platforms{"x64","x86"}
+   platforms{"x64","x86"}
 
    -- A project defines one build target
-   project "demo3d-target0-x86"
+   project "demo3d-target0"
       kind "ConsoleApp"
-     language "C++"
-   --   "../../src_proc0/pc/*.*","../../src_proc0/common/*.*","../../src_proc0/nmgl/*.*",
-      files { "../../../include/*.h","../include/*.h","../src_target0/*.*","../src_target0/tests/*.*","../../../nmglvs_mc12101-gcc/src_nmc0/*.*","../../../src_proc0/pc/*.*","../../../src_proc0/common/*.*" }
+	  language "C++"
+      files { "../../../include/*.h", "../include/*.h", "../src_target0/*.cpp", "../src_target0/tests/*.*",  "../../../nmglvs_mc12101-gcc/src_nmc0/*.*" }
 	  libdirs { "$(NMPP)/lib","$(HAL)/lib", "../../../lib"}
 	  includedirs { "$(MC12101)/include","$(HAL)/include","$(NMPP)/include","../../../include","../include"}
-     links { "nmpp-x86.lib"} 
-     defines { "TEST_NMGL_TEX_FUNC" } 
-     configuration "Debug"
-         defines { "DEBUG" }
-         symbols  "On"
-         links { "nmopengl-x86d.lib","hal-virtual-x86d.lib"}   
- 
-      configuration "Release"
-         defines { "NDEBUG" }
-         symbols  "Off" 
-         links { "nmopengl-x86.lib","hal-virtual-x86.lib"}
-         
-solution "demo3d-target1-x86"
+	  defines { "TEST_NMGL_TEX_FUNC"}
+	  configuration {"Debug","x86"}
+			links { "nmpp-x86d.lib","hal-virtual-x86d.lib"," nmopengl-x86d.lib"}
+			targetsuffix ("-x86d")
+			architecture "x32"
+			defines { "DEBUG", "EMULATION"}
+			symbols  "On" 
+	  configuration {"Release","x86"}
+			links { "nmpp-x86.lib","hal-virtual-x86.lib"," nmopengl-x86.lib"}
+			targetsuffix ("-x86")
+			architecture "x32"
+			defines { "NDEBUG", "EMULATION"}
+			symbols  "Off" 
+	  configuration {"Debug","x64"}
+			links { "nmpp-x64d.lib","hal-virtual-x64d.lib", "nmopengl-x64d.lib"}
+			targetsuffix ("-x64d")
+			architecture "x64"
+			defines { "DEBUG"}
+			symbols  "On" 
+	  configuration {"Release","x64"}
+			links { "nmpp-x64.lib","hal-virtual-x64.lib", "nmopengl-x64.lib"}
+			targetsuffix ("-x64")
+			architecture "x64"
+			defines { "NDEBUG", "EMULATION"}
+			symbols  "Off" 
+		 
+solution "demo3d-target1"
    configurations { "Debug", "Release" }
-   --platforms{"x64","x86"}
+   platforms{"x64","x86"}
 
    -- A project defines one build target
-   project "demo3d-target1-x86"
+   project "demo3d-target1"
       kind "ConsoleApp"
-     language "C++"
-   -- "../../../src_proc1/pc/*.*","../../../src_proc1/common/*.*",
-      files { "../../../include/*.h","../src_target1/*.*", "../../../nmglvs_mc12101-gcc/src_nmc1/*.*","../../../src_proc1/pc/*.*","../../../src_proc1/common/*.*"}
-	  libdirs { "$(NMPP)/lib","$(HAL)/lib", "$(VSHELL)/lib", "../../../lib"}
-	  includedirs { "$(MC12101)/include","$(HAL)/include","$(NMPP)/include","../../../include", "$(VSHELL)/include"}
-     links { "nmpp-x86.lib", "vshell.lib"}
-     defines { "TEST_NMGL_TEX_FUNC" }
-      configuration "Debug"
-         defines { "DEBUG" }
-         symbols  "On" 
-         links { "nmopengl-x86d.lib","hal-virtual-x86d.lib"}
-
-      configuration "Release"
-         defines { "NDEBUG" }
-         symbols  "Off" 	   
-         links { "nmopengl-x86.lib","hal-virtual-x86.lib"}
-  
-       
+	  language "C++"
+      files { "../../../include/*.h","../src_target1/*.cpp", "../../../nmglvs_mc12101-gcc/src_nmc1/*.*"  }
+	  libdirs { "$(NMPP)/lib","$(HAL)/lib", "../../../lib"}
+	  includedirs { "$(MC12101)/include","$(HAL)/include","$(NMPP)/include","../../../include"}
+	  defines { "TEST_NMGL_TEX_FUNC"}
+	  configuration {"Debug","x86"}
+			links { "nmpp-x86d.lib","hal-virtual-x86d.lib"," nmopengl-x86d.lib"}
+			targetsuffix ("-x86d")
+			architecture "x32"
+			defines { "DEBUG", "EMULATION"}
+			symbols  "On" 
+	  configuration {"Release","x86"}
+			links { "nmpp-x86.lib","hal-virtual-x86.lib"," nmopengl-x86.lib"}
+			targetsuffix ("-x86")
+			architecture "x32"
+			defines { "NDEBUG", "EMULATION"}
+			symbols  "Off" 
+	  configuration {"Debug","x64"}
+			links { "nmpp-x64d.lib","hal-virtual-x64d.lib", "nmopengl-x64d.lib"}
+			targetsuffix ("-x64d")
+			architecture "x64"
+			defines { "DEBUG"}
+			symbols  "On" 
+	  configuration {"Release","x64"}
+			links { "nmpp-x64.lib","hal-virtual-x64.lib", "nmopengl-x64.lib"}
+			targetsuffix ("-x64")
+			architecture "x64"
+			defines { "NDEBUG", "EMULATION"}
+			symbols  "Off" 
+		   
+		  

--- a/app/templates/project/make_x86/Makefile
+++ b/app/templates/project/make_x86/Makefile
@@ -13,6 +13,12 @@ TARGET0   = demo3d-target0
 TARGET1   = demo3d-target1
 HOST      = demo3d-host
 
+ifeq ($(CONFIGURATION),Debug)
+	TARGET_SUFFIX = d
+else
+	TARGET_SUFFIX = 
+endif
+
 VS ?=vs2015
 ALL: $(VS)
 .PHONY = vs2005 vs2015
@@ -45,13 +51,13 @@ run:
 	$(MAKE) -j4 runhost runtarget0  runtarget1 
 
 runhost: $(HOST)
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget0: $(TARGET0) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget1: $(TARGET1) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 
 include $(ROOT)/clean.mk

--- a/app/templates/projectdebug/make_x86/Makefile
+++ b/app/templates/projectdebug/make_x86/Makefile
@@ -13,6 +13,12 @@ TARGET0   = demo3d-target0
 TARGET1   = demo3d-target1
 HOST      = demo3d-host
 
+ifeq ($(CONFIGURATION),Debug)
+	TARGET_SUFFIX = d
+else
+	TARGET_SUFFIX = 
+endif
+
 VS ?=vs2015
 ALL: $(VS)
 .PHONY = vs2005 vs2015
@@ -45,13 +51,13 @@ run:
 	$(MAKE) -j4 runhost runtarget0  runtarget1 
 
 runhost: $(HOST)
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget0: $(TARGET0) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget1: $(TARGET1) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 
 include $(ROOT)/clean.mk

--- a/drawLineTest/make_x86/Makefile
+++ b/drawLineTest/make_x86/Makefile
@@ -13,6 +13,12 @@ TARGET0   = demo3d-target0
 TARGET1   = demo3d-target1
 HOST      = demo3d-host
 
+ifeq ($(CONFIGURATION),Debug)
+	TARGET_SUFFIX = d
+else
+	TARGET_SUFFIX = 
+endif
+
 VS ?=vs2015
 ALL: $(VS)
 .PHONY = vs2005 vs2015
@@ -45,13 +51,13 @@ run:
 	$(MAKE) -j4 runhost runtarget0  runtarget1 
 
 runhost: $(HOST)
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(HOST)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget0: $(TARGET0) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET0)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 runtarget1: $(TARGET1) 
-	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)
+	bin\$(PLATFORM)\$(CONFIGURATION)\$(TARGET1)-$(PLATFORM)$(TARGET_SUFFIX)
 	
 
 include $(ROOT)/clean.mk


### PR DESCRIPTION
* Исправлены ошибки сборки модульных тестов для текстурных функций nmOpenGL для версии x86 (app/nmgltex_tests/make_x86). Были ошибки линковки, связанные с тем, что Make-файлы и premake не были скорректированы под использование 64-битных версий библиотек (в частности vshell). Для исправления этих ошибок Makefile и premake5.lua были скорректированы в соответствии с файлами из app/template/project/make_x86/ .

* Исправлены ошибки при запуске debug x86 версий некоторых приложений с помощью команды 'make run':
  	* app/template/project.
	* app/template/projectdebug
	* app/nmgltex_tests/
	* drawLineTest
	* 2nmc-demo-gcc
	* 2nmc-demo-gcc-example
  Цель 'run' в make_x86/Makefile не учитывала суффикс 'd', добавляемый к исполняемому файлу при сборке. Для исправления ошибки в Makefile была добавлена переменная TARGET_SUFFIX.

Примечание:
При запуске из консоли с помощью команды 'make run' приложения x86 не всегда запускаются с первого раза по неизвестной причине. Лучше  запускаются, если есть задержки между запуском demo3d-host, demo3d-target0 и demo3d-target1.