### PR TITLE
Исправлены ошибки тестов функций текстурирования + замена статической памяти текстур на динамическую

### DIFF
--- a/app/nmgltex_tests/src_target0/tests/nmglBindTexture_tests.cpp
+++ b/app/nmgltex_tests/src_target0/tests/nmglBindTexture_tests.cpp
@@ -13,7 +13,7 @@ extern void* cntxtAddr_nm1;
 #endif
 extern NMGL_Context_NM1 *cntxt_nm1;
 extern unsigned int nmpu1IsAccessible;
-extern NMGLubyte mipmap[MIPMAP_MEM_SIZE];
+extern NMGLubyte* mipmap;
 extern int getTexelSizeUbytes(NMGLint format);
 int isPowerOf2(NMGLint x);
 

--- a/app/nmgltex_tests/src_target0/tests/nmglColorTableEXT_tests.cpp
+++ b/app/nmgltex_tests/src_target0/tests/nmglColorTableEXT_tests.cpp
@@ -103,23 +103,26 @@ int nmglColorTableEXT_setColorTable_contextCorrect()
 	}
 	nmglColorTableEXT (NMGL_TEXTURE_2D, NMGL_RGBA, cwidth, NMGL_RGBA, NMGL_UNSIGNED_BYTE, data);
 	wait_for_nm1_if_available;
-DEBUG_PRINT(("cwidth=%d\n0width=%d\n1width=%d\n",cwidth,cntxt->texState.texObjects[0].palette.width,cntxt_nm1->texState.texObjects[0].palette.width));
+	DEBUG_PRINT(("cwidth=%d\n0width=%d\n", cwidth, cntxt->texState.texObjects[0].palette.width));
 	TEST_ASSERT(cntxt->texState.texObjects[0].palette.width == cwidth);
-	if(nmpu1IsAccessible == 1) {TEST_ASSERT(cntxt_nm1->texState.texObjects[0].palette.width == cwidth);}
+	if(nmpu1IsAccessible == 1) {
+		DEBUG_PRINT(("cwidth=%d\n1width=%d\n", cwidth, cntxt_nm1->texState.texObjects[0].palette.width));
+		TEST_ASSERT(cntxt_nm1->texState.texObjects[0].palette.width == cwidth);
+	}
 	
 	for (i=0;i<cwidth*RGBA_TEXEL_SIZE_UBYTE;i++)
 	{
 		if(*((NMGLubyte*)data+i) != *((NMGLubyte*)(cntxt->texState.texObjects[0].palette.colors+i)))
 		{
 			
-			printf("i=%d\ndata[%d]=%x pale[%d]=%d data_nm1[%d]\n",i,i,*((NMGLubyte*)data+i),i,*((NMGLubyte*)(cntxt->texState.texObjects[0].palette.colors+i)),i,*((NMGLubyte*)(cntxt_nm1->texState.texObjects[0].palette.colors+i)));
+			printf("i=%d\ndata[%d]=%x pale[%d]=%d data_nm0[%d]\n",i,i,*((NMGLubyte*)data+i),i,*((NMGLubyte*)(cntxt->texState.texObjects[0].palette.colors+i)),i);
 			TEST_ASSERT(0);
 		}
 		if(nmpu1IsAccessible == 1)
 		{
 			if(*((NMGLubyte*)data+i) != *((NMGLubyte*)(cntxt_nm1->texState.texObjects[0].palette.colors+i)))
 			{
-					printf("i=%d\n pale[%d]=%d data_nm1[%d]\n",i,i,*((NMGLubyte*)(cntxt->texState.texObjects[0].palette.colors+i)),i,*((NMGLubyte*)(cntxt_nm1->texState.texObjects[0].palette.colors+i)));
+				printf("i=%d\ndata[%d]=%x pale[%d]=%d data_nm1[%d]\n",i,i, *((NMGLubyte*)data + i), i, *((NMGLubyte*)(cntxt_nm1->texState.texObjects[0].palette.colors + i)), i);
 				TEST_ASSERT(0);
 			}
 		}

--- a/app/nmgltex_tests/src_target0/tests/nmglTexImage2D_tests.cpp
+++ b/app/nmgltex_tests/src_target0/tests/nmglTexImage2D_tests.cpp
@@ -72,7 +72,7 @@ pname:TEXTURE_WRAP_S,TEXTURE_WRAP_T
 #pragma code_section ".text_tex_tests"
 #pragma data_section ".data_tex_tests"
 #endif
-extern NMGLubyte mipmap[MIPMAP_MEM_SIZE];
+extern NMGLubyte* mipmap;
 NMGL_Context_NM0 *cntxt;
 //extern void* cntxtAddr_nm1;
 extern unsigned int nmpu1IsAccessible;

--- a/app/nmgltex_tests/src_target0/tests/nmglTexSubImage2D_tests.cpp
+++ b/app/nmgltex_tests/src_target0/tests/nmglTexSubImage2D_tests.cpp
@@ -56,8 +56,7 @@ const void *pixels);
 int nmglTexSubImage2D_TexSubImage_contextStateCorrect();
 int nmglTexSubImage2D_wrongArgs_isError();
 ////////////EXTERN/////////////////////////////////////////////////////////////////////////////////////
-extern NMGLubyte mipmap[MIPMAP_MEM_SIZE];
-extern NMGLubyte mipmap[MIPMAP_MEM_SIZE];
+extern NMGLubyte* mipmap;
 extern NMGL_Context_NM0 *cntxt;
 extern void* cntxtAddr_nm1;
 //========================================================================================

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -33,6 +33,9 @@ SECTION(".data_imu6") int dividedMasksMemory[4][3 * NMGL_SIZE / 32];
 
 SECTION(".data_imu6") int masksBits[36][3 * NMGL_SIZE / 32];
 
+
+extern  NMGLubyte* mipmap; //texture memory
+
 int counter = 0;
 
 template<class T> inline T* myMallocT() {
@@ -91,6 +94,12 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		cntxt->beginEndInfo.color = myMallocT<v4nm32f>(BIG_NMGL_SIZE);
 		cntxt->beginEndInfo.inBeginEnd = false;
 		cntxt->beginEndInfo.maxSize = BIG_NMGL_SIZE;
+		
+		//Allocate memory for textures.
+		//Must be in EMI. 
+		//EMI has enough space and does not require address mapping at mc12101
+		setHeap(12);
+		mipmap = myMallocT<NMGLubyte>(MIPMAP_MEM_SIZE); 
 	}
 	catch (int& e) {
 		halHostSync(0xDEADB00F);

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -101,7 +101,11 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 	cntxt->patterns = (PatternsArray*)halSyncAddr(synchroData, 1);
 	halSyncAddr(polygonsData, 1);
 #ifdef TEST_NMGL_TEX_FUNC
-       cntxtAddr_nm1 = (void*)halSyncAddr(0, 1);	   
+	cntxtAddr_nm1 = (void*)halSyncAddr(0, 1);
+#ifndef __NM__
+	cntxtAddr_nm1 = 0; //static shared memory is not supported in x86 model
+#endif //__NM__
+       	   
 #endif //TEST_NMGL_TEX_FUNC
 	halHostSync(0x600DB00F);	// send ok to host
 

--- a/src_proc0/nmgl/nmglTexImage2D.cpp
+++ b/src_proc0/nmgl/nmglTexImage2D.cpp
@@ -5,7 +5,7 @@
 //#include "malloc.h" //func malloc
 //#include "nmtype.h" //func malloc32
 //#define DEBUG
-SECTION(".textures_mipmap_mem")  NMGLubyte mipmap[MIPMAP_MEM_SIZE];
+SECTION(".data_imu1")  NMGLubyte* mipmap; //texture memory
 
 //Alternative: #pragma data_section ".data_imu1"
 //     double x1[SIZE];


### PR DESCRIPTION
* При запуске модульных тестов функций текстурирования в  модели x86  были ошибки во время выполнения в связи с доступом из процесса nmpu0 к "статической" памяти процесса nmpu1 (доступ к контексту nmpu1). 
    1) Доступ выполнялся ошибочно по нулевому указателю, 
    2) Также доступ выполнялся по не нулевому указателю (был не равен 0 по умолчанию), но доступа к "статической" памяти процесса nmpu1 из процесса nmpu0 нет, поэтому тоже были ошибки доступа к памяти. 
Для исправления ошибок был скорректирован один тест + для x86 адрес контекста nmpu1 для nmpu0 принудительно устанавливается равным 0.

* Статическая память для хранения текстур заменена на динамическую. Это позволяет уменьшить время запуска приложения на mc12101, за счёт уменьшения размера программы. Также при использовании статической памяти нельзя было бы запускать приложения с текстурированием в модели x86, так как в модели x86 поддерживается только общая для процессоров динамически выделяемая память, а текстурная память является общей для nmpu0 и nmpu1.