### PR TITLE
Correct Begin/End implementation

### DIFF
--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -182,8 +182,6 @@ public:
 	v4nm32f* normal;
 	v4nm32f* color;
 	int vertexCounter;
-	int normalCounter;
-	int colorCounter;
 
 	NMGLenum mode;
 	bool inBeginEnd;
@@ -193,8 +191,6 @@ public:
 
 	NmglBeginEndInfo(){
 		vertexCounter = 0;
-		normalCounter = 0;
-		colorCounter = 0;
 		inBeginEnd = false;
 	}
 
@@ -266,6 +262,8 @@ public:
 	Lines lineInner;
 	Points pointInner;
 	NmglBeginEndInfo beginEndInfo;
+	v4nm32f currentColor;
+	v4nm32f currentNormal;
 
 	mat4nm32f modelviewMatrix[16];
 	mat4nm32f projectionMatrix[2];
@@ -317,6 +315,15 @@ public:
 		specularExp = 0;
 		isLighting = NMGL_FALSE;
 
+		currentColor.vec[0] = (float)1.0;
+		currentColor.vec[1] = (float)1.0;
+		currentColor.vec[2] = (float)1.0;
+		currentColor.vec[3] = (float)1.0;
+
+		currentNormal.vec[0] = (float)0.0;
+		currentNormal.vec[1] = (float)0.0;
+		currentNormal.vec[2] = (float)1.0;
+		currentNormal.vec[3] = (float)0.0;
 
 		modelviewMatrixStack.base = modelviewMatrix;
 		modelviewMatrixStack.current = 0;

--- a/src_proc0/nmgl/nmglBegin.cpp
+++ b/src_proc0/nmgl/nmglBegin.cpp
@@ -16,8 +16,6 @@ void nmglBegin(NMGLenum mode)
 	cntxt->beginEndInfo.inBeginEnd = true;
 	cntxt->beginEndInfo.mode = mode;
 	cntxt->beginEndInfo.vertexCounter = 0;
-	cntxt->beginEndInfo.normalCounter = 0;
-	cntxt->beginEndInfo.colorCounter = 0;
 	//printf("begin\n");
 	
 }

--- a/src_proc0/nmgl/nmglColor.cpp
+++ b/src_proc0/nmgl/nmglColor.cpp
@@ -5,56 +5,42 @@
 
 #pragma code_section ".text_nmgl"
 
-#define CHECK_SIZE()	if (cntxt->beginEndInfo.colorCounter == cntxt->beginEndInfo.maxSize - 1) { \
-		cntxt->error = NMGL_OUT_OF_MEMORY;	\
-		return;								\
-	}
-
 SECTION(".text_nmgl")
 void nmglColor4f(NMGLfloat red, NMGLfloat green, NMGLfloat blue, NMGLfloat alpha)
 {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
-	CHECK_SIZE();
-	int i = cntxt->beginEndInfo.colorCounter;
-	cntxt->beginEndInfo.color[i].vec[0] = red;
-	cntxt->beginEndInfo.color[i].vec[1] = green;
-	cntxt->beginEndInfo.color[i].vec[2] = blue;
-	cntxt->beginEndInfo.color[i].vec[3] = alpha;
-	cntxt->beginEndInfo.colorCounter++;
+	cntxt->currentColor.vec[0] = red;
+	cntxt->currentColor.vec[1] = green;
+	cntxt->currentColor.vec[2] = blue;
+	cntxt->currentColor.vec[3] = alpha;
 }
 
 SECTION(".text_nmgl")
 void nmglColor4ub(NMGLubyte red, NMGLubyte green, NMGLubyte blue, NMGLubyte alpha)
 {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
-	CHECK_SIZE();
-	int i = cntxt->beginEndInfo.colorCounter;
-	cntxt->beginEndInfo.color[i].vec[0] = (float)red/RED_COEFF;
-	cntxt->beginEndInfo.color[i].vec[1] = (float)green/ GREEN_COEFF;
-	cntxt->beginEndInfo.color[i].vec[2] = (float)blue/BLUE_COEFF;
-	cntxt->beginEndInfo.color[i].vec[3] = (float)alpha/ALPHA_COEFF;
-	cntxt->beginEndInfo.colorCounter++;
+	cntxt->currentColor.vec[0] = (float)red / RED_COEFF;
+	cntxt->currentColor.vec[1] = (float)green / GREEN_COEFF;
+	cntxt->currentColor.vec[2] = (float)blue / BLUE_COEFF;
+	cntxt->currentColor.vec[3] = (float)alpha/ALPHA_COEFF;
 }
 
 SECTION(".text_nmgl")
 void nmglColor4fv(NMGLfloat *v)
 {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
-	CHECK_SIZE();
-	int i = cntxt->beginEndInfo.colorCounter;
-	cntxt->beginEndInfo.color[i].vec[0] = v[0];
-	cntxt->beginEndInfo.color[i].vec[1] = v[1];
-	cntxt->beginEndInfo.color[i].vec[2] = v[2];
-	cntxt->beginEndInfo.color[i].vec[3] = v[3];
-	cntxt->beginEndInfo.colorCounter++;
+	cntxt->currentColor.vec[0] = v[0];
+	cntxt->currentColor.vec[1] = v[1];
+	cntxt->currentColor.vec[2] = v[2];
+	cntxt->currentColor.vec[3] = v[3];
 }
 
 SECTION(".text_nmgl")
 void nmglColor4ubv(NMGLubyte *v)
 {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
-	CHECK_SIZE();
-	int i = cntxt->beginEndInfo.colorCounter;
-	nmppsConvert_32s32f(v, (float*)(cntxt->beginEndInfo.color + i), 4);
-	cntxt->beginEndInfo.colorCounter++;
+	cntxt->currentColor.vec[0] = (float)v[0];
+	cntxt->currentColor.vec[1] = (float)v[1];
+	cntxt->currentColor.vec[2] = (float)v[2];
+	cntxt->currentColor.vec[3] = (float)v[3];
 }

--- a/src_proc0/nmgl/nmglEnd.cpp
+++ b/src_proc0/nmgl/nmglEnd.cpp
@@ -23,13 +23,15 @@ void nmglEnd ()
 	nmblas_scopy(sizeof32(Array), (float*)&cntxt->normalArray, 1, (float*)&normalArrayTmp, 1);
 	nmblas_scopy(sizeof32(Array), (float*)&cntxt->colorArray, 1, (float*)&colorArrayTmp, 1);
 
-	cntxt->vertexArray.enabled = cntxt->beginEndInfo.vertexCounter != 0;
+	NMGLboolean arrayEnabled = cntxt->beginEndInfo.vertexCounter != 0;
+	
+	cntxt->vertexArray.enabled = arrayEnabled;
 	nmglVertexPointer(4, NMGL_FLOAT, 0, cntxt->beginEndInfo.vertex);
 
-	cntxt->normalArray.enabled = cntxt->beginEndInfo.normalCounter != 0;
+	cntxt->normalArray.enabled = arrayEnabled;
 	nmglNormalPointerNM(NMGL_FLOAT, 0, cntxt->beginEndInfo.normal);
 
-	cntxt->colorArray.enabled = cntxt->beginEndInfo.colorCounter != 0;
+	cntxt->colorArray.enabled = arrayEnabled;
 	nmglColorPointer(4, NMGL_FLOAT, 0, cntxt->beginEndInfo.color);
 	
 	//printf("vertexCounter=%d\n", cntxt->beginEndInfo.vertexCounter);

--- a/src_proc0/nmgl/nmglNormal.cpp
+++ b/src_proc0/nmgl/nmglNormal.cpp
@@ -4,33 +4,22 @@
 
 #pragma code_section ".text_nmgl"
 
-#define CHECK_SIZE()	if (cntxt->beginEndInfo.normalCounter == cntxt->beginEndInfo.maxSize - 1) { \
-		cntxt->error = NMGL_OUT_OF_MEMORY;	\
-		return;								\
-	}
-
 SECTION(".text_nmgl")
 void nmglNormal3f(NMGLfloat x, NMGLfloat y, NMGLfloat z)
 {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
-	CHECK_SIZE();
-	int i = cntxt->beginEndInfo.normalCounter;
-	cntxt->beginEndInfo.normal[i].vec[0] = x;
-	cntxt->beginEndInfo.normal[i].vec[1] = y;
-	cntxt->beginEndInfo.normal[i].vec[2] = z;
-	cntxt->beginEndInfo.normal[i].vec[3] = 0;
-	cntxt->beginEndInfo.normalCounter++;
+	cntxt->currentNormal.vec[0] = x;
+	cntxt->currentNormal.vec[1] = y;
+	cntxt->currentNormal.vec[2] = z;
+	cntxt->currentNormal.vec[3] = 0;
 }
 
 SECTION(".text_nmgl")
 void nmglNormal3fv(const NMGLfloat *v)
 {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
-	CHECK_SIZE();
-	int i = cntxt->beginEndInfo.normalCounter;
-	cntxt->beginEndInfo.normal[i].vec[0] = v[0];
-	cntxt->beginEndInfo.normal[i].vec[1] = v[1];
-	cntxt->beginEndInfo.normal[i].vec[2] = v[2];
-	cntxt->beginEndInfo.normal[i].vec[3] = 0;
-	cntxt->beginEndInfo.normalCounter++;
+	cntxt->currentNormal.vec[0] = v[0];
+	cntxt->currentNormal.vec[1] = v[1];
+	cntxt->currentNormal.vec[2] = v[2];
+	cntxt->currentNormal.vec[3] = 0;
 }

--- a/src_proc0/nmgl/nmglVertex.cpp
+++ b/src_proc0/nmgl/nmglVertex.cpp
@@ -19,6 +19,17 @@ void nmglVertex2f(NMGLfloat x, NMGLfloat y)
 	cntxt->beginEndInfo.vertex[i].vec[1] = y;
 	cntxt->beginEndInfo.vertex[i].vec[2] = 0;
 	cntxt->beginEndInfo.vertex[i].vec[3] = 1;
+
+	cntxt->beginEndInfo.color[i].vec[0] = cntxt->currentColor.vec[0];
+	cntxt->beginEndInfo.color[i].vec[1] = cntxt->currentColor.vec[1];
+	cntxt->beginEndInfo.color[i].vec[2] = cntxt->currentColor.vec[2];
+	cntxt->beginEndInfo.color[i].vec[3] = cntxt->currentColor.vec[3];
+
+	cntxt->beginEndInfo.normal[i].vec[0] = cntxt->currentNormal.vec[0];
+	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
+	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
+	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+
 	cntxt->beginEndInfo.vertexCounter++;
 }
 
@@ -32,6 +43,17 @@ void nmglVertex3f(NMGLfloat x, NMGLfloat y, NMGLfloat z)
 	cntxt->beginEndInfo.vertex[i].vec[1] = y;
 	cntxt->beginEndInfo.vertex[i].vec[2] = z;
 	cntxt->beginEndInfo.vertex[i].vec[3] = 1;
+
+	cntxt->beginEndInfo.color[i].vec[0] = cntxt->currentColor.vec[0];
+	cntxt->beginEndInfo.color[i].vec[1] = cntxt->currentColor.vec[1];
+	cntxt->beginEndInfo.color[i].vec[2] = cntxt->currentColor.vec[2];
+	cntxt->beginEndInfo.color[i].vec[3] = cntxt->currentColor.vec[3];
+
+	cntxt->beginEndInfo.normal[i].vec[0] = cntxt->currentNormal.vec[0];
+	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
+	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
+	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+
 	cntxt->beginEndInfo.vertexCounter++;
 }
 
@@ -45,6 +67,17 @@ void nmglVertex2fv(const NMGLfloat *v)
 	cntxt->beginEndInfo.vertex[i].vec[1] = v[1];
 	cntxt->beginEndInfo.vertex[i].vec[2] = 0;
 	cntxt->beginEndInfo.vertex[i].vec[3] = 1;
+
+	cntxt->beginEndInfo.color[i].vec[0] = cntxt->currentColor.vec[0];
+	cntxt->beginEndInfo.color[i].vec[1] = cntxt->currentColor.vec[1];
+	cntxt->beginEndInfo.color[i].vec[2] = cntxt->currentColor.vec[2];
+	cntxt->beginEndInfo.color[i].vec[3] = cntxt->currentColor.vec[3];
+
+	cntxt->beginEndInfo.normal[i].vec[0] = cntxt->currentNormal.vec[0];
+	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
+	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
+	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+
 	cntxt->beginEndInfo.vertexCounter++;
 }
 
@@ -58,5 +91,16 @@ void nmglVertex3fv(const NMGLfloat *v)
 	cntxt->beginEndInfo.vertex[i].vec[1] = v[1];
 	cntxt->beginEndInfo.vertex[i].vec[2] = v[2];
 	cntxt->beginEndInfo.vertex[i].vec[3] = 1;
+
+	cntxt->beginEndInfo.color[i].vec[0] = cntxt->currentColor.vec[0];
+	cntxt->beginEndInfo.color[i].vec[1] = cntxt->currentColor.vec[1];
+	cntxt->beginEndInfo.color[i].vec[2] = cntxt->currentColor.vec[2];
+	cntxt->beginEndInfo.color[i].vec[3] = cntxt->currentColor.vec[3];
+
+	cntxt->beginEndInfo.normal[i].vec[0] = cntxt->currentNormal.vec[0];
+	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
+	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
+	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+
 	cntxt->beginEndInfo.vertexCounter++;
 }


### PR DESCRIPTION
There were bug in Begin/End implementation. Calls to glColor and lNormal
added color and normal to the corresponding arrays in Begin/End
implementation like glVertex function. So number of calls to glColor
and glNormal should have been equal to number of glVertex calls. But in
OpenGL there may be only one call to glColor or there may be a lot of
glColor calls before glVertex calls and primitive will have color from last
glColor call. So glColor and glNormal should setup current value of
color/normal that is used later as vertex attribute when glVertex is called.

This commit correct Begin/End implementation:
* Add fields for current values of color and normal to nm0 context.
* Add setup of initial values of current color and normal to nm0 context.
* Current color and normal values are copied to color and normal arrays in
  nmglVertex() instead of nmglColor() and nmglNormal(). nmglColor() and
  nmglNormal() only setup current values of color and normal.
* Remove color and normal counters.
* Enabling of color and normal arrays was changed. Color and normal arrays are
  enabled if there were call to nmglVertex (vertexColor > 0).