### PR TITLE
Add support of nmglMultiTexCoord2{f,fv} to nmOpenGL

### DIFF
--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -181,12 +181,14 @@ public:
 	v4nm32f* vertex;
 	v4nm32f* normal;
 	v4nm32f* color;
+#ifdef TEXTURE_ENABLED
+	v2nm32f* texcoord;//XXX: Only one texture unit is supported.
+#endif //TEXTURE_ENABLED
 	int vertexCounter;
 
 	NMGLenum mode;
 	bool inBeginEnd;
 
-	int dummy;
 	int maxSize;
 
 	NmglBeginEndInfo(){

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -122,6 +122,9 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		cntxt->beginEndInfo.vertex = myMallocT<v4nm32f>(BIG_NMGL_SIZE);
 		cntxt->beginEndInfo.normal = myMallocT<v4nm32f>(BIG_NMGL_SIZE);
 		cntxt->beginEndInfo.color = myMallocT<v4nm32f>(BIG_NMGL_SIZE);
+#ifdef TEXTURE_ENABLED
+		cntxt->beginEndInfo.texcoord = myMallocT<v2nm32f>(BIG_NMGL_SIZE); //XXX: Only one texture unit is supported.
+#endif //TEXTURE_ENABLED
 		cntxt->beginEndInfo.inBeginEnd = false;
 		cntxt->beginEndInfo.maxSize = BIG_NMGL_SIZE;
 #ifdef STACK_TRACE_ENABLED		

--- a/src_proc0/nmgl/nmglEnd.cpp
+++ b/src_proc0/nmgl/nmglEnd.cpp
@@ -7,6 +7,9 @@
 SECTION(".data_imu7") Array vertexArrayTmp;
 SECTION(".data_imu7") Array normalArrayTmp;
 SECTION(".data_imu7") Array colorArrayTmp;
+#ifdef TEXTURE_ENABLED
+SECTION(".data_imu7") Array texcoordArrayTmp; //XXX: Only one texture unit is supported. So one tmpArray.
+#endif //TEXTURE_ENABLED
 
 SECTION(".text_nmgl")
 void nmglEnd ()
@@ -22,6 +25,11 @@ void nmglEnd ()
 	nmblas_scopy(sizeof32(Array), (float*)&cntxt->vertexArray, 1, (float*)&vertexArrayTmp, 1);
 	nmblas_scopy(sizeof32(Array), (float*)&cntxt->normalArray, 1, (float*)&normalArrayTmp, 1);
 	nmblas_scopy(sizeof32(Array), (float*)&cntxt->colorArray, 1, (float*)&colorArrayTmp, 1);
+#ifdef TEXTURE_ENABLED
+	nmblas_scopy(sizeof32(Array), (float*)&cntxt->texState.texcoordArray[0], 1, (float*)&texcoordArrayTmp, 1); //XXX: Only one texture unit is supported.
+	NMGLenum clientActiveTexUnitTmp = cntxt->texState.clientActiveTexUnit;
+	unsigned int clientActiveTexUnitIndexTmp = cntxt->texState.clientActiveTexUnitIndex;
+#endif //TEXTURE_ENABLED
 
 	NMGLboolean arrayEnabled = cntxt->beginEndInfo.vertexCounter != 0;
 	
@@ -34,12 +42,26 @@ void nmglEnd ()
 	cntxt->colorArray.enabled = arrayEnabled;
 	nmglColorPointer(4, NMGL_FLOAT, 0, cntxt->beginEndInfo.color);
 	
+#ifdef TEXTURE_ENABLED
+	//XXX: Only one texture unit is supported.
+	cntxt->texState.clientActiveTexUnit = NMGL_TEXTURE0;
+	cntxt->texState.clientActiveTexUnitIndex = 0;
+	cntxt->texState.texcoordArray[0].enabled = cntxt->vertexArray.enabled = arrayEnabled;
+	nmglTexCoordPointer(2, NMGL_FLOAT, 0, cntxt->beginEndInfo.texcoord);
+	
+#endif //TEXTURE_ENABLED
+	
 	//printf("vertexCounter=%d\n", cntxt->beginEndInfo.vertexCounter);
 	nmglDrawArrays(cntxt->beginEndInfo.mode, 0, cntxt->beginEndInfo.vertexCounter);
 
 	nmblas_scopy(sizeof32(Array), (float*)&vertexArrayTmp, 1, (float*)&cntxt->vertexArray, 1);
 	nmblas_scopy(sizeof32(Array), (float*)&normalArrayTmp, 1, (float*)&cntxt->normalArray, 1);
 	nmblas_scopy(sizeof32(Array), (float*)&colorArrayTmp, 1, (float*)&cntxt->colorArray, 1);
+#ifdef TEXTURE_ENABLED
+	nmblas_scopy(sizeof32(Array), (float*)&texcoordArrayTmp, 1,(float*)&cntxt->texState.texcoordArray[0], 1); //XXX: Only one texture unit is supported.
+	cntxt->texState.clientActiveTexUnit = clientActiveTexUnitTmp;
+	cntxt->texState.clientActiveTexUnitIndex = clientActiveTexUnitIndexTmp;
+#endif //TEXTURE_ENABLED
 	//printf("end\n\n");
 	
 }

--- a/src_proc0/nmgl/nmglVertex.cpp
+++ b/src_proc0/nmgl/nmglVertex.cpp
@@ -30,6 +30,12 @@ void nmglVertex2f(NMGLfloat x, NMGLfloat y)
 	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
 	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
 
+#ifdef TEXTURE_ENABLED
+	//XXX: Only one texture unit is supported.
+	cntxt->beginEndInfo.texcoord[i].v0 = cntxt->texState.curTexCoords[0].s;
+	cntxt->beginEndInfo.texcoord[i].v1 = cntxt->texState.curTexCoords[0].t;
+#endif //TEXTURE_ENABLED
+	
 	cntxt->beginEndInfo.vertexCounter++;
 }
 
@@ -53,6 +59,12 @@ void nmglVertex3f(NMGLfloat x, NMGLfloat y, NMGLfloat z)
 	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
 	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
 	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+	
+#ifdef TEXTURE_ENABLED
+	//XXX: Only one texture unit is supported.
+	cntxt->beginEndInfo.texcoord[i].v0 = cntxt->texState.curTexCoords[0].s;
+	cntxt->beginEndInfo.texcoord[i].v1 = cntxt->texState.curTexCoords[0].t;
+#endif //TEXTURE_ENABLED
 
 	cntxt->beginEndInfo.vertexCounter++;
 }
@@ -77,6 +89,12 @@ void nmglVertex2fv(const NMGLfloat *v)
 	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
 	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
 	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+	
+#ifdef TEXTURE_ENABLED
+	//XXX: Only one texture unit is supported.
+	cntxt->beginEndInfo.texcoord[i].v0 = cntxt->texState.curTexCoords[0].s;
+	cntxt->beginEndInfo.texcoord[i].v1 = cntxt->texState.curTexCoords[0].t;
+#endif //TEXTURE_ENABLED
 
 	cntxt->beginEndInfo.vertexCounter++;
 }
@@ -101,6 +119,12 @@ void nmglVertex3fv(const NMGLfloat *v)
 	cntxt->beginEndInfo.normal[i].vec[1] = cntxt->currentNormal.vec[1];
 	cntxt->beginEndInfo.normal[i].vec[2] = cntxt->currentNormal.vec[2];
 	cntxt->beginEndInfo.normal[i].vec[3] = cntxt->currentNormal.vec[3];
+	
+#ifdef TEXTURE_ENABLED
+	//XXX: Only one texture unit is supported.
+	cntxt->beginEndInfo.texcoord[i].v0 = cntxt->texState.curTexCoords[0].s;
+	cntxt->beginEndInfo.texcoord[i].v1 = cntxt->texState.curTexCoords[0].t;
+#endif //TEXTURE_ENABLED
 
 	cntxt->beginEndInfo.vertexCounter++;
 }


### PR DESCRIPTION
nmglMultiTexCoord was part of nmOpenGL but it could not be used because
the values that this function setup were not used anywhere in pipeline.
This commit add using of current texture coordinates that are setup by
nmglMultiTexCoord2{f,fv} in Begin/End:
* Add texcoord array to BeginEndInfo structure to store texture coordinates
  that were setup in Begin/End. Remove dummy int from BeginEndInfo because test
  applications  (2nmc-demo-gcc, ...) didn't work with it after adding
  texcoord array to BeginEndInfo.
* Add using current texture coordinates (from nm0 texture context) in
  glVertex. Current texture coordinates are placed to texcoord array
  from BeginEndInfo.
* nmglEnd was corrected to use values that were placed to texcoord array
  in Begin/End. nmglTexCoordPointer is used to setup values from
  BeginEndInfo texcoord array. Backup of old texcoord array is created like
  for color or normal pointer. Also backups for clientActiveTexUnit and
  clientActiveTexUnitIndex are created.

Only one texcoord array in BeginEndInfo is used because only one
texture unit is supported in nmOpenGL.