### PR TITLE
Fix unit tests for convertABGR32_RGB565

### DIFF
--- a/test/crc/convertABGR32_RGB565/main.cpp
+++ b/test/crc/convertABGR32_RGB565/main.cpp
@@ -85,7 +85,7 @@ int convertABGR32_RGB565_nInputValues_nOutputValues(int n)
     }
 
     //Act
-    int res = convertABGR32_RGB565(srcArray, dstArray, count);
+    convertABGR32_RGB565(srcArray, dstArray, count);
 
     //Assert
     // Get the elements from the dstArray and expectedDstArray, 


### PR DESCRIPTION
Tests didn't build because the return value of void function was used