### PR TITLE
Fix build error for textureTriangle nmpu0 test

### DIFF
--- a/test/nmpu0/textureTriangle/main.cpp
+++ b/test/nmpu0/textureTriangle/main.cpp
@@ -139,7 +139,6 @@ int main ()
 	synchroData.init();
 	NMGL_Context_NM0::create(&synchroData);	
 	test_cntxt = NMGL_Context_NM0::getContext();
-	test_cntxt->init(&synchroData);
 	
     //Массивы растеризованных и закрашенных треугольников
 	nm32s pSrcTriangle[WIDTH_PTRN * HEIGHT_PTRN * 1];


### PR DESCRIPTION
Test built with error because "init" method of NMGL_Context_NM0 was changed.
At now "init" has no arguments and is called from "create" method of NMGL_Context_NM0.