### PR TITLE
Fix texture data transmission for triangles

### DIFF
--- a/src_proc1/common/nmgl_drawtriangles.cpp
+++ b/src_proc1/common/nmgl_drawtriangles.cpp
@@ -28,6 +28,29 @@ SECTION(".text_demo3d") void NMGL_DrawTriangles(NMGL_Context_NM1 *context, Comma
 	nmppsCopy_32s(poly->color, context->buffer0, 4 * poly->count);
 	nmppsConvert_32s8s(context->buffer0, (nm8s*)context->valuesC, 4 * poly->count);
 	nmppsCopy_32s(poly->z, context->valuesZ, poly->count);
+#ifdef TEXTURE_ENABLED
+	if (context->texState.textureEnabled) {
+		for (int i = 0; i < poly->count; i++) {
+			context->x0[i] = (float)poly->x0[i] + context->texState.segX0;
+			context->y0[i] = (float)poly->y0[i] + context->texState.segY0;
+			context->x1[i] = (float)poly->x1[i] + context->texState.segX0;
+			context->y1[i] = (float)poly->y1[i] + context->texState.segY0;
+			context->x2[i] = (float)poly->x2[i] + context->texState.segX0;
+			context->y2[i] = (float)poly->y2[i] + context->texState.segY0;
+
+			context->texS0[i] = poly->s0[i];
+			context->texT0[i] = poly->t0[i];
+			context->texS1[i] = poly->s1[i];
+			context->texT1[i] = poly->t1[i];
+			context->texS2[i] = poly->s2[i];
+			context->texT2[i] = poly->t2[i];
+
+			context->w0[i] = poly->w0[i];
+			context->w1[i] = poly->w1[i];
+			context->w2[i] = poly->w2[i];
+		}
+	}
+#endif //TEXTURE_ENABLED
 	msdWaitDma(1);
 
 	poly->count = 0;

--- a/src_proc1/common/readPolygonsT.cpp
+++ b/src_proc1/common/readPolygonsT.cpp
@@ -173,29 +173,6 @@ SECTION(".text_demo3d") int getAddrPtrnsT(DataForNmpu1* data) {
 		(nm32u**)cntxt->ppPtrns2_2s,
 		(nm32u**)cntxt->ppPtrnsCombined_2s,
 		cntxt->nSizePtrn32, size);
-#ifdef TEXTURE_ENABLED
-	if (cntxt->texState.textureEnabled) {
-		for (int i = 0; i < size; i++) {
-			cntxt->x0[i] = (float)dataTmp->x0[i] + cntxt->texState.segX0;
-			cntxt->y0[i] = (float)dataTmp->y0[i] + cntxt->texState.segY0;
-			cntxt->x1[i] = (float)dataTmp->x1[i] + cntxt->texState.segX0;
-			cntxt->y1[i] = (float)dataTmp->y1[i] + cntxt->texState.segY0;
-			cntxt->x2[i] = (float)dataTmp->x2[i] + cntxt->texState.segX0;
-			cntxt->y2[i] = (float)dataTmp->y2[i] + cntxt->texState.segY0;
-
-			cntxt->texS0[i] = dataTmp->s0[i];
-			cntxt->texT0[i] = dataTmp->t0[i];
-			cntxt->texS1[i] = dataTmp->s1[i];
-			cntxt->texT1[i] = dataTmp->t1[i];
-			cntxt->texS2[i] = dataTmp->s2[i];
-			cntxt->texT2[i] = dataTmp->t2[i];
-
-			cntxt->w0[i] = dataTmp->w0[i];
-			cntxt->w1[i] = dataTmp->w1[i];
-			cntxt->w2[i] = dataTmp->w2[i];
-		}
-	}
-#endif //TEXTURE_ENABLED
 
 	//этот кусок кода является си-реализацией этой функции и является более наглядным	
 	/*for (int i = 0; i < size; i++) {


### PR DESCRIPTION
readPolygonsT copied first 7 fields of "DataForNmpu1" structure to
dataTmp variable. So there was no texture data in dataTmp when texture
data were copied to cntxt from dataTmp.
Texture data copying was moved to nmgl_drawtriangles function because
Color and Z values are copied to cntxt from DataForNmpu1 in nmgl_drawtriangles.