### PR TITLE
Fix return condition of repackToPrimitives_t (asm implementation)

### DIFF
--- a/src_proc0/nm/repackToPrimitives_t.asm
+++ b/src_proc0/nm/repackToPrimitives_t.asm
@@ -145,8 +145,9 @@ begin ".text_demo3d"			// начало секции кода
 
 	gr0 = 0;
 	[retVal] = gr0;
-	gr6;
-	if =0 goto Exit;
+	gr0 = 3;
+	gr6 - gr0;
+	if < goto Exit;
 
 	// Выгрузка координат x точек A всех треугольников для mode=GL_TRIANGLES
 	// Get number of triangles 


### PR DESCRIPTION
This function can't do anything when the number of vertices is less than 3.
In this case just return 0