### PR TITLE
Add logic for glEnable and glDisable of COLOR_MATERIAL

### DIFF
--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -291,6 +291,8 @@ public:
 	v4nm32f materialDiffuse;			///< Рассеяный цвет материала
 	v4nm32f materialSpecular;			///< Зеркальный цвет материала
 	v4nm32f materialEmissive;			///< Эмиссионный цвет материала
+	v4nm32f *pMaterialAmbient;	///< Указатель на окружающий цвет материала (materialAmbient), используется в GetMaterialfv и в формуле расчёта цветапри включенном освещении
+	v4nm32f *pMaterialDiffuse;	///< Указатель на зеркальный цвет материала (materialDiffuse), используется в GetMaterialfv и в формуле расчёта цветапри включенном освещении
 
 	v4nm32f lightAmbient[MAX_LIGHTS + 1];   ///< Значения окружающей интенсивности источников света (элемент MAX_LIGHTS говорит об интенсивности сцены)
 	v4nm32f lightDiffuse[MAX_LIGHTS];       ///< Значения рассеяной интенсивности источников света
@@ -304,6 +306,7 @@ public:
 	float lightQuadAtt[MAX_LIGHTS];			///< Квадратичный коэффициент затухания для источника света (не используется)
 	int isEnabledLight[MAX_LIGHTS];		///< Флаги активности источников света
 	int isLighting;						///< Флаг активности расчета освещения
+	int isColorMaterial;				///< Флаг активности режима COLOR_MATERIAL
 	float specularExp;					///< Показатель зеркальности
 
 	NMGL_Context_NM0_Texture texState; 	///< textures data
@@ -355,6 +358,8 @@ public:
 		materialEmissive.vec[1] = 0.0f;
 		materialEmissive.vec[2] = 0.0f;
 		materialEmissive.vec[3] = 1.0f;
+		pMaterialAmbient = &materialAmbient;
+		pMaterialDiffuse = &materialDiffuse;
 
 		for (int i = 0; i < MAX_LIGHTS; i++) {
 			if (i == 0) {

--- a/include/tests.h
+++ b/include/tests.h
@@ -41,12 +41,33 @@ if (!(x)) \
 	for (__i = 0; __i < size; ++__i){ \
 		if (!equalf(array1[__i], array2[__i])) { \
 			printf ("\nFAIL Function: %s\n     File:%s\n     Line:%d\n     Cond:%s\n",__FUNCTION__, __FILE__, __LINE__, "all elements of arrays are equal"); \
+			printf ("\n%i: %f != %f\n\r", __i, array1[__i], array2[__i]);\
 			printf ("     Details: " __VA_ARGS__);\
 			printf ("\n\n");\
 			return -1; \
 		} else { \
 			/* Do nothing, continue to the next element */ \
 		} \
+	} \
+}
+
+#define TEST_ARRAYS_NOT_EQUAL(array1, array2, size, ...) \
+{ \
+	int __i; \
+	int __res = -1; \
+	for (__i = 0; __i < size; ++__i){ \
+		if (!equalf(array1[__i], array2[__i])) { \
+			__res = 0;\
+			break;\
+		}\
+	}\
+	if (-1 == __res) { \
+		printf ("\nFAIL Function: %s\n     File:%s\n     Line:%d\n     Cond:%s\n",__FUNCTION__, __FILE__, __LINE__, "Arrays are not equal"); \
+		printf ("     Details: " __VA_ARGS__);\
+		printf ("\n\n");\
+		return -1; \
+	} else { \
+		/* Do nothing, continue to the next element */ \
 	} \
 }
 

--- a/include/tests.h
+++ b/include/tests.h
@@ -41,7 +41,6 @@ if (!(x)) \
 	for (__i = 0; __i < size; ++__i){ \
 		if (!equalf(array1[__i], array2[__i])) { \
 			printf ("\nFAIL Function: %s\n     File:%s\n     Line:%d\n     Cond:%s\n",__FUNCTION__, __FILE__, __LINE__, "all elements of arrays are equal"); \
-			printf ("\n%i: %f != %f\n\r", __i, array1[__i], array2[__i]);\
 			printf ("     Details: " __VA_ARGS__);\
 			printf ("\n\n");\
 			return -1; \
@@ -135,6 +134,12 @@ if (!(x)) \
 #define RUN_ARG_TEST(f, arg) \
 	if(f(arg) == 0) {\
 		printf ("OK   Function: %s(%i)\n", #f, arg);\
+	}
+
+//Macro to run test with two arguments. usage: RUN_TEST_2ARGS(functionMane_condition_result,arg1, arg2)
+#define RUN_TEST_2ARGS(f, arg1, arg2) \
+	if(f(arg1, arg2) == 0) {\
+		printf ("OK   Function: %s(%i, %i)\n", #f, arg1, arg2);\
 	}
 
 #endif /* TESTS_H_ */

--- a/src_proc0/nmgl/nmglDisable.cpp
+++ b/src_proc0/nmgl/nmglDisable.cpp
@@ -26,7 +26,11 @@ void nmglDisable(NMGLenum cap) {
 		break;
 
 	case NMGL_COLOR_MATERIAL:
-		//code
+		cntxt->isColorMaterial = NMGL_FALSE;
+		cntxt->materialAmbient = *cntxt->pMaterialAmbient;// i.e. currentColor
+		cntxt->materialDiffuse = *cntxt->pMaterialDiffuse;// i.e. currentColor
+		cntxt->pMaterialAmbient = &cntxt->materialAmbient;
+		cntxt->pMaterialDiffuse = &cntxt->materialDiffuse;
 		break;		
 		
 	case NMGL_CULL_FACE:

--- a/src_proc0/nmgl/nmglDrawArrays.cpp
+++ b/src_proc0/nmgl/nmglDrawArrays.cpp
@@ -146,8 +146,8 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 	}
 
 	if (cntxt->isLighting) {
-		mulC_v4nm32f(cntxt->lightAmbient, &cntxt->materialAmbient, cntxt->ambientMul, MAX_LIGHTS + 1);
-		mulC_v4nm32f(cntxt->lightDiffuse, &cntxt->materialDiffuse, cntxt->diffuseMul, MAX_LIGHTS);
+		mulC_v4nm32f(cntxt->lightAmbient, cntxt->pMaterialAmbient, cntxt->ambientMul, MAX_LIGHTS + 1);
+		mulC_v4nm32f(cntxt->lightDiffuse, cntxt->pMaterialDiffuse, cntxt->diffuseMul, MAX_LIGHTS);
 		mulC_v4nm32f(cntxt->lightSpecular, &cntxt->materialSpecular, cntxt->specularMul, MAX_LIGHTS);
 		nmppsAdd_32f((float*)(cntxt->ambientMul + MAX_LIGHTS), 
 			(float*)&cntxt->materialEmissive, 

--- a/src_proc0/nmgl/nmglEnable.cpp
+++ b/src_proc0/nmgl/nmglEnable.cpp
@@ -26,7 +26,9 @@ void nmglEnable(NMGLenum cap) {
 		break;
 
 	case NMGL_COLOR_MATERIAL:
-		//code
+		cntxt->isColorMaterial = NMGL_TRUE;
+		cntxt->pMaterialAmbient = &cntxt->currentColor;
+		cntxt->pMaterialDiffuse = &cntxt->currentColor;
 		break;		
 		
 	case NMGL_CULL_FACE:


### PR DESCRIPTION
Add new flag isColorMaterial and pointers to materialAmbient and materialDiffuse.  These pointers are used in a color calculation with lighting enabled and in glGetMaterialfv. Ambient and diffuse colors of material must track the current color. It is easier to use pointers here and switch them between the current color and the values set with glMaterialfv.