### PR TITLE
Fix color check in lightf and lightfv functions

### DIFF
--- a/src_proc0/nmgl/nmglLightf.cpp
+++ b/src_proc0/nmgl/nmglLightf.cpp
@@ -8,7 +8,7 @@ SECTION(".text_nmgl")
 void nmglLightf(NMGLenum color, NMGLenum pname, NMGLfloat param) {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
 	color -= NMGL_LIGHT0;
-	if (color > MAX_LIGHTS) {
+	if (color >= MAX_LIGHTS) {
 		cntxt->error = NMGL_INVALID_ENUM;
 		return;
 	}

--- a/src_proc0/nmgl/nmglLightfv.cpp
+++ b/src_proc0/nmgl/nmglLightfv.cpp
@@ -8,7 +8,7 @@ SECTION(".text_nmgl")
 void nmglLightfv(NMGLenum color, NMGLenum pname, const NMGLfloat *params) {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
 	color -= NMGL_LIGHT0;
-	if (color > MAX_LIGHTS) {
+	if (color >= MAX_LIGHTS) {
 		cntxt->error = NMGL_INVALID_ENUM;
 		return;
 	}


### PR DESCRIPTION
Color offset must be greater or equal than MAX_LIGHTS because
MAX_LIGHTS is a length of some arrays (lightAmbient, ...). Color equal
to MAX_LIGHTS will cause out of border access.