### PR TITLE
Add filter functions and tests for them

### DIFF
--- a/include/filter.h
+++ b/include/filter.h
@@ -1,0 +1,804 @@
+#ifndef __FILTER_H__
+#define __FILTER_H__
+
+extern "C" {
+
+/*
+ * Init function for performance test
+ */
+static void maskInit(nm1* maskEven, nm1* maskOdd, int evenValue, int oddValue, int count)
+{
+
+  int* maskEvenTmp = (int*)maskEven;
+  int* maskOddTmp= (int*)maskOdd;
+
+  for (int i=0; i<count; i++) {
+    maskEvenTmp[i] = evenValue;
+    maskOddTmp[i] = oddValue;
+  }
+
+}
+
+  /*!
+   *  \defgroup cnvDividedMaskToIndices cnvDividedMaskToIndices
+   *  \ingroup filter_api 
+   *  \brief Формирование массива индексов единичных элементов чётной и нечётной масок. Чётная и нечётная маски являются частями объединённой маски и содержат соответственно чётные и нечётные элементы объединённой маски.
+   *  \author 
+   *  \param maskEven [in] Чётная маска 
+   *  \param maskOdd [in]  Нечётная маска
+   *  \param indices [out] Выходной массив индексов 
+   *  \param size [in] Суммарное количество элементов объединённой маски, которое необходимо проанализировать
+   *  
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="indices"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0x0, 0x0, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="indices"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0xFFFFFFFF, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="indices"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0xFFFFFFFF, 0x00000000, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="indices"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0x00000000, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *  \endxmlonly
+   */
+  //! \{
+  int cnvDividedMaskToIndices(nm1* maskEven, nm1* maskOdd, int* indices, int size);
+  //! \}
+
+
+  /*!
+   *  \defgroup cnvDividedMaskToOffsets cnvDividedMaskToOffsets
+   *  \ingroup filter_api 
+   *  \brief Формирование массива смещений между единичными элементами чётной и нечётной масок. Чётная и нечётная маски являются частями объединённой маски и содержат соответственно чётные и нечётные элементы объединённой маски.
+   *  \author 
+   *  \param maskEven [in] Чётная маска 
+   *  \param maskOdd [in]  Нечётная маска 
+   *  \param offsets[out] Выходной массив смещений 
+   *  \param size [in] Суммарное количество элементов объединённой маски, которое необходимо проанализировать
+   *  
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="offsets"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0x0, 0x0, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="offsets"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0xFFFFFFFF, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="offsets"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0xFFFFFFFF, 0x00000000, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="maskEven"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="maskOdd"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="offsets"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(maskEven, maskOdd, 0x00000000, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *  \endxmlonly
+   */
+  //! \{
+int cnvDividedMaskToOffsets(nm1* maskEven, nm1* maskOdd, int* offsets, int size);
+  //! \}
+
+
+  /*!
+   *  \defgroup cnvMaskToIndices cnvMaskToIndices
+   *  \ingroup filter_api 
+   *  \brief Формирование массива индексов между единичными элементами маски
+   *  \author 
+   *  \param mask [in] Маска
+   *  \param indices[out] Выходной массив индексов 
+   *  \param size [in] Количество элементов маски, которое необходимо проанализировать
+   *  
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="indices"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0x0, 0x0, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="indices"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0xFFFFFFFF, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="indices"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0x55555555, 0x55555555, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="indices"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0xAAAAAAAA, 0xAAAAAAAA, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *  \endxmlonly
+   */
+  //! \{
+int cnvMaskToIndices(nm1* mask, int* indices, int size);
+  //! \}
+
+
+  /*!
+   *  \defgroup cnvMaskToOffsets cnvMaskToOffsets
+   *  \ingroup filter_api 
+   *  \brief Формирование массива смещений между единичными элементами маски
+   *  \author 
+   *  \param mask [in] Маска 
+   *  \param offsets[out] Выходной массив смещений 
+   *  \param size [in] Число элементов
+   *  
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="offsets"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0x0, 0x0, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="offsets"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0xFFFFFFFF, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="offsets"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0x55555555, 0x55555555, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="mask"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="offsets"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            maskInit(mask, mask, 0xAAAAAAAA, 0xAAAAAAAA, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *  \endxmlonly
+   */
+  //! \{
+int cnvMaskToOffsets(nm1* mask, int* offsets, int size);
+  //! \}
+
+
+
+/*
+ * Init function for performance test
+ */
+static void offsetsInit(int* offsets, int value, int count)
+{
+
+  for (int i=0; i<count; i++) {
+    offsets[i] = value;
+  }
+
+}
+
+  /*!
+   *  \defgroup selectElementsByOffsets selectElementsByOffsets 
+   *  \ingroup filter_api 
+   *  \brief Функция копирует элементы входного массива, определяемые массивом смещений между элементами, в выходной массив.
+   *  \author 
+   *  \param src [in] Входной массив элементов 
+   *  \param offsets[in] Массив смещений 
+   *  \param dst [out] Выходной массив элементов
+   *  \param sizeOfElementInt [in] Размер элемента в int'ах
+   *  \param size [in] Число элементов
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="offsets"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dst"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="sizeOfElementInt"> 1 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            offsetsInit(offsets, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="src"> im00 </param>
+   *          <param name="offsets"> im01 </param>
+   *          <param name="dst"> im02 </param>
+   *          <param name="sizeOfElementInt"> 1 2 4 8 16 32</param>
+   *          <param name="size"> 1 2 4 8 16 32</param>
+   *          <init>
+   *            offsetsInit(offsets, 0xFFFFFFFF, size/32);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  void selectElementsByOffsets(void* src, int* offsets, void* dst, int sizeOfElementInt, int size);
+  //! \}
+
+
+/*
+ * Init function for performance test
+ */
+static void indicesInit(int* indices, int count)
+{
+
+  for (int i=0; i<count; i++) {
+    indices[i] = i;
+  }
+
+}
+
+  /*!
+   *  \defgroup selectElementsByIndices selectElementsByIndices 
+   *  \ingroup filter_api 
+   *  \brief Функция копирует элементы входного массива с заданными индексами в выходной массив
+   *  \author 
+   *  \param src [in] Входной массив элементов 
+   *  \param indices[in] Массив индексов 
+   *  \param dst [out] Выходной массив элементов
+   *  \param sizeOfElementInt [in] Размер элемента в int'ах
+   *  \param size [in] Число элементов
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="indices"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dst"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="sizeOfElementInt"> 1 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            indicesInit(indices, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="src"> im00 </param>
+   *          <param name="indices"> im01 </param>
+   *          <param name="dst"> im02 </param>
+   *          <param name="sizeOfElementInt"> 1 2 4 8 16 32</param>
+   *          <param name="size"> 1 2 4 8 16 32</param>
+   *          <init>
+   *            indicesInit(indices, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  void selectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size);
+  //! \}
+
+
+  /*!
+   *  \defgroup deselectElementsByIndices deselectElementsByIndices 
+   *  \ingroup filter_api 
+   *  \brief Функция копирует элементы входного массива в элементы выходного массива с заданными индексами
+   *  \author 
+   *  \param src [in] Входной массив элементов 
+   *  \param indices[in] Массив индексов 
+   *  \param dst [out] Выходной массив элементов
+   *  \param sizeOfElementInt [in] Размер элемента в int'ах
+   *  \param size [in] Число копируемых элементов
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="indices"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dst"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="sizeOfElementInt"> 1 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            indicesInit(indices, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *      <testperf>
+   *          <param name="src"> im00 </param>
+   *          <param name="indices"> im01 </param>
+   *          <param name="dst"> im02 </param>
+   *          <param name="sizeOfElementInt"> 1 2 4 8 16 32</param>
+   *          <param name="size"> 1 2 4 8 16 32</param>
+   *          <init>
+   *            indicesInit(indices, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  void deselectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size);
+  //! \}
+/*
+ * Init function for performance test
+ */
+static void cmpSrcInit(float* src, int count)
+{
+
+  for (int i=0; i<count; i++) {
+    src[i] = 1.0;
+  }
+
+}
+
+  /*!
+   *  \defgroup cmpGtC_f cmpGtC_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет сравнение элементов входного массива с константой по признаку 'Больше'
+   *  \author 
+   *  \param src [in] Входной массив элементов для сравнения
+   *  \param С[in] Константа для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов входного массива с константой
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов входного массива с константой
+   *  \param size [in] Число элементов входного массива для сравнения
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="C"> 0.0 </param>
+   *          <param name="dstMaskEven"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskOdd"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            cmpSrcInit(src, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpGtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+
+  /*!
+   *  \defgroup cmpLtC_f cmpLtC_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет сравнение элементов входного массива с константой по признаку 'Меньше'
+   *  \author 
+   *  \param src [in] Входной массив элементов для сравнения
+   *  \param С[in] Константа для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов входного массива с константой
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов входного массива с константой
+   *  \param size [in] Число элементов входного массива для сравнения
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="C"> 2.0 </param>
+   *          <param name="dstMaskEven"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskOdd"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            cmpSrcInit(src, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpLtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+
+  /*!
+   *  \defgroup cmpGteC_f cmpGteC_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет сравнение элементов входного массива с константой по признаку 'Больше или равно'
+   *  \author 
+   *  \param src [in] Входной массив элементов для сравнения
+   *  \param С[in] Константа для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов входного массива с константой
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов входного массива с константой
+   *  \param size [in] Число элементов входного массива для сравнения
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="C"> 0.0 </param>
+   *          <param name="dstMaskEven"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskOdd"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            cmpSrcInit(src, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpGteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+
+  /*!
+   *  \defgroup cmpLteC_f cmpLteC_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет сравнение элементов входного массива с константой по признаку 'Меньше или равно'
+   *  \author 
+   *  \param src [in] Входной массив элементов для сравнения
+   *  \param С[in] Константа для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов входного массива с константой
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов входного массива с константой
+   *  \param size [in] Число элементов входного массива для сравнения
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="C"> 2.0 </param>
+   *          <param name="dstMaskEven"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskOdd"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            cmpSrcInit(src, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpLteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+  /*!
+   *  \defgroup cmpEqC_f cmpEqC_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет сравнение элементов входного массива с константой по признаку 'Равно'
+   *  \author 
+   *  \param src [in] Входной массив элементов для сравнения
+   *  \param С[in] Константа для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов входного массива с константой
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов входного массива с константой
+   *  \param size [in] Число элементов входного массива для сравнения
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="C"> 1.0 </param>
+   *          <param name="dstMaskEven"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskOdd"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            cmpSrcInit(src, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpEqC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+  /*!
+   *  \defgroup cmpNeC_f cmpNeC_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет сравнение элементов входного массива с константой по признаку 'Не равно'
+   *  \author 
+   *  \param src [in] Входной массив элементов для сравнения
+   *  \param С[in] Константа для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов входного массива с константой
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов входного массива с константой
+   *  \param size [in] Число элементов входного массива для сравнения
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="C"> 0.0 </param>
+   *          <param name="dstMaskEven"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskOdd"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <init>
+   *            cmpSrcInit(src, size);
+   *          </init>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpNeC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+ 
+  /*!
+   *  \defgroup cmpGtV_f cmpGtV_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет поэлементное сравнение двух массивов по признаку 'Больше'
+   *  \author 
+   *  \param src1 [in] Входной массив 1 для сравнения
+   *  \param src2 [in] Входной массив 2 для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов массивов
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов массивов
+   *  \param size [in] Количество сравниваемых элементов 
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src1"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="src2"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskEven"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="dstMaskOdd"> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpGtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+  /*!
+   *  \defgroup cmpGteV_f cmpGteV_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет поэлементное сравнение двух массивов по признаку 'Больше или равно'
+   *  \author 
+   *  \param src1 [in] Входной массив 1 для сравнения
+   *  \param src2 [in] Входной массив 2 для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов массивов
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов массивов
+   *  \param size [in] Количество сравниваемых элементов 
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src1"> im00 im10 im30 im30 im40 im50 im60 im70 </param>
+   *          <param name="src2"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskEven"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="dstMaskOdd"> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpGteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+  /*!
+   *  \defgroup cmpLtV_f cmpLtV_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет поэлементное сравнение двух массивов по признаку 'Меньше'
+   *  \author 
+   *  \param src1 [in] Входной массив 1 для сравнения
+   *  \param src2 [in] Входной массив 2 для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов массивов
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов массивов
+   *  \param size [in] Количество сравниваемых элементов 
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src1"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="src2"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskEven"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="dstMaskOdd"> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpLtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+  /*!
+   *  \defgroup cmpLteV_f cmpLteV_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет поэлементное сравнение двух массивов по признаку 'Меньше или равно'
+   *  \author 
+   *  \param src1 [in] Входной массив 1 для сравнения
+   *  \param src2 [in] Входной массив 2 для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов массивов
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов массивов
+   *  \param size [in] Количество сравниваемых элементов 
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src1"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="src2"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskEven"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="dstMaskOdd"> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpLteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+
+  /*!
+   *  \defgroup cmpEqV_f cmpEqV_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет поэлементное сравнение двух массивов по признаку 'Равно'
+   *  \author 
+   *  \param src1 [in] Входной массив 1 для сравнения
+   *  \param src2 [in] Входной массив 2 для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов массивов
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов массивов
+   *  \param size [in] Количество сравниваемых элементов 
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src1"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="src2"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskEven"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="dstMaskOdd"> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpEqV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+
+
+  /*!
+   *  \defgroup cmpNeV_f cmpNeV_f  
+   *  \ingroup filter_api 
+   *  \brief Функция выполняет поэлементное сравнение двух массивов по признаку 'Не равно'
+   *  \author 
+   *  \param src1 [in] Входной массив 1 для сравнения
+   *  \param src2 [in] Входной массив 2 для сравнения
+   *  \param dstMaskEven [out] Выходная битовая маска. Результат сравнения чётных элементов массивов
+   *  \param dstMaskOdd [out] Выходная битовая маска. Результат сравнения нечётных элементов массивов
+   *  \param size [in] Количество сравниваемых элементов 
+   *  
+   *  \par
+   *  \xmlonly
+   *      <testperf>
+   *          <param name="src1"> im00 im10 im20 im30 im40 im50 im60 im70 </param>
+   *          <param name="src2"> im01 im11 im21 im31 im41 im51 im61 im71 </param>
+   *          <param name="dstMaskEven"> im02 im12 im22 im32 im42 im52 im62 im72 </param>
+   *          <param name="dstMaskOdd"> im03 im13 im23 im33 im43 im53 im63 im73 </param>
+   *          <param name="size"> 128 256 512 1024 </param>
+   *          <size> size </size>
+   *      </testperf>
+   *
+   *  \endxmlonly
+   */
+  //! \{
+  //
+  void cmpNeV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size); 
+  //! \}
+}
+
+
+#endif 

--- a/src_proc0/nm/cmpEqC_f.asm
+++ b/src_proc0/nm/cmpEqC_f.asm
@@ -1,0 +1,123 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+  dupC: long = 0hl;
+
+end ".data_demo3d";
+
+//void cmpEqC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpEqC_f: label;
+
+begin ".text_demo3d"
+<_cmpEqC_f>
+	ar5 = ar7 - 2;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src
+	ar3 = [--ar5]; // C
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpEqC_f;
+    nul;
+    gr3 = ar3;
+
+  [dupC] = ar3,gr3;
+  ar3 = dupC with gr3 = false;
+
+	fpu 0 rep 1 vreg1 = [ar3];
+	ar3 = gr3;
+	sir = ar3, gr3;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpEqC_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpEqC_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if =0;
+	gr2--;
+	if > delayed goto CmpEqC_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpEqC_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpEqC_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if =0;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpEqC_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpEqC_f.asm
+++ b/src_proc0/nm/cmpEqC_f.asm
@@ -1,49 +1,6 @@
+extern shiftedZeroes: word;
 data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
   dupC: long = 0hl;
-
 end ".data_demo3d";
 
 //void cmpEqC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);

--- a/src_proc0/nm/cmpEqV_f.asm
+++ b/src_proc0/nm/cmpEqV_f.asm
@@ -1,0 +1,121 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+end ".data_demo3d";
+
+//void cmpEqV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpEqV_f: label;
+
+begin ".text_demo3d"
+<_cmpEqV_f>
+	ar5 = ar7 - 2;
+	push ar4, gr4;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src1
+	ar3 = [--ar5] with gr4 = false; // src2 
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpEqV_f;
+    nul;
+    nul;
+
+	ar4 = gr4; 
+	sir = ar4, gr4;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpEqV_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpEqV_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src1
+	fpu 0 rep 32 vreg1 = [ar3++]; 						// читаем 64 элемента массива src2
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if =0;
+	gr2--;
+	if > delayed goto CmpEqV_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpEqV_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpEqV_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 rep vlen vreg1 = [ar3++];
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if =0;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpEqV_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	pop ar4, gr4;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpEqV_f.asm
+++ b/src_proc0/nm/cmpEqV_f.asm
@@ -1,48 +1,4 @@
-data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
-end ".data_demo3d";
+extern shiftedZeroes: word;
 
 //void cmpEqV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 global _cmpEqV_f: label;

--- a/src_proc0/nm/cmpGtC_f.asm
+++ b/src_proc0/nm/cmpGtC_f.asm
@@ -1,49 +1,6 @@
+extern shiftedZeroes: word;
 data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
   dupC: long = 0hl;
-
 end ".data_demo3d";
 
 //void cmpGtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);

--- a/src_proc0/nm/cmpGtC_f.asm
+++ b/src_proc0/nm/cmpGtC_f.asm
@@ -1,0 +1,123 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+  dupC: long = 0hl;
+
+end ".data_demo3d";
+
+//void cmpGtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpGtC_f: label;
+
+begin ".text_demo3d"
+<_cmpGtC_f>
+	ar5 = ar7 - 2;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src
+	ar3 = [--ar5]; // C
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpGtC_f;
+    nul;
+    gr3 = ar3;
+
+  [dupC] = ar3,gr3;
+  ar3 = dupC with gr3 = false;
+
+	fpu 0 rep 1 vreg1 = [ar3];
+	ar3 = gr3;
+	sir = ar3, gr3;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpGtC_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpGtC_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if >;
+	gr2--;
+	if > delayed goto CmpGtC_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpGtC_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpGtC_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if >;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpGtC_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpGtV_f.asm
+++ b/src_proc0/nm/cmpGtV_f.asm
@@ -1,48 +1,4 @@
-data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
-end ".data_demo3d";
+extern shiftedZeroes: word;
 
 //void cmpGtV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 global _cmpGtV_f: label;

--- a/src_proc0/nm/cmpGtV_f.asm
+++ b/src_proc0/nm/cmpGtV_f.asm
@@ -1,0 +1,121 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+end ".data_demo3d";
+
+//void cmpGtV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpGtV_f: label;
+
+begin ".text_demo3d"
+<_cmpGtV_f>
+	ar5 = ar7 - 2;
+	push ar4, gr4;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src1
+	ar3 = [--ar5] with gr4 = false; // src2 
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpGtV_f;
+    nul;
+    nul;
+
+	ar4 = gr4; 
+	sir = ar4, gr4;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpGtV_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpGtV_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src1
+	fpu 0 rep 32 vreg1 = [ar3++]; 						// читаем 64 элемента массива src2
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if >;
+	gr2--;
+	if > delayed goto CmpGtV_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpGtV_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpGtV_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 rep vlen vreg1 = [ar3++];
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if >;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpGtV_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	pop ar4, gr4;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpGteC_f.asm
+++ b/src_proc0/nm/cmpGteC_f.asm
@@ -1,49 +1,6 @@
+extern shiftedZeroes: word;
 data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
   dupC: long = 0hl;
-
 end ".data_demo3d";
 
 //void cmpGteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);

--- a/src_proc0/nm/cmpGteC_f.asm
+++ b/src_proc0/nm/cmpGteC_f.asm
@@ -1,0 +1,123 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+  dupC: long = 0hl;
+
+end ".data_demo3d";
+
+//void cmpGteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpGteC_f: label;
+
+begin ".text_demo3d"
+<_cmpGteC_f>
+	ar5 = ar7 - 2;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src
+	ar3 = [--ar5]; // C
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpGtC_f;
+    nul;
+    gr3 = ar3;
+
+  [dupC] = ar3,gr3;
+  ar3 = dupC with gr3 = false;
+
+	fpu 0 rep 1 vreg1 = [ar3];
+	ar3 = gr3;
+	sir = ar3, gr3;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpGtC_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpGtC_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if >=;
+	gr2--;
+	if > delayed goto CmpGtC_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpGtC_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpGtC_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if >=;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpGtC_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpGteV_f.asm
+++ b/src_proc0/nm/cmpGteV_f.asm
@@ -1,0 +1,121 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+end ".data_demo3d";
+
+//void cmpGteV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpGteV_f: label;
+
+begin ".text_demo3d"
+<_cmpGteV_f>
+	ar5 = ar7 - 2;
+	push ar4, gr4;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src1
+	ar3 = [--ar5] with gr4 = false; // src2 
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpGtV_f;
+    nul;
+    nul;
+
+	ar4 = gr4; 
+	sir = ar4, gr4;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpGtV_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpGtV_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src1
+	fpu 0 rep 32 vreg1 = [ar3++]; 						// читаем 64 элемента массива src2
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if >=;
+	gr2--;
+	if > delayed goto CmpGtV_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpGtV_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpGtV_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 rep vlen vreg1 = [ar3++];
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if >=;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpGtV_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	pop ar4, gr4;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpGteV_f.asm
+++ b/src_proc0/nm/cmpGteV_f.asm
@@ -1,48 +1,4 @@
-data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
-end ".data_demo3d";
+extern shiftedZeroes: word;
 
 //void cmpGteV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 global _cmpGteV_f: label;

--- a/src_proc0/nm/cmpLtC_f.asm
+++ b/src_proc0/nm/cmpLtC_f.asm
@@ -1,49 +1,6 @@
+extern shiftedZeroes: word;
 data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
   dupC: long = 0hl;
-
 end ".data_demo3d";
 
 //void cmpLtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);

--- a/src_proc0/nm/cmpLtC_f.asm
+++ b/src_proc0/nm/cmpLtC_f.asm
@@ -1,0 +1,123 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+  dupC: long = 0hl;
+
+end ".data_demo3d";
+
+//void cmpLtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpLtC_f: label;
+
+begin ".text_demo3d"
+<_cmpLtC_f>
+	ar5 = ar7 - 2;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src
+	ar3 = [--ar5]; // C
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpLtC_f;
+    nul;
+    gr3 = ar3;
+
+  [dupC] = ar3,gr3;
+  ar3 = dupC with gr3 = false;
+
+	fpu 0 rep 1 vreg1 = [ar3];
+	ar3 = gr3;
+	sir = ar3, gr3;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpLtC_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpLtC_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if <;
+	gr2--;
+	if > delayed goto CmpLtC_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpLtC_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpLtC_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if <;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpLtC_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpLtV_f.asm
+++ b/src_proc0/nm/cmpLtV_f.asm
@@ -1,48 +1,4 @@
-data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
-end ".data_demo3d";
+extern shiftedZeroes: word;
 
 //void cmpLtV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 global _cmpLtV_f: label;

--- a/src_proc0/nm/cmpLtV_f.asm
+++ b/src_proc0/nm/cmpLtV_f.asm
@@ -1,0 +1,121 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+end ".data_demo3d";
+
+//void cmpLtV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpLtV_f: label;
+
+begin ".text_demo3d"
+<_cmpLtV_f>
+	ar5 = ar7 - 2;
+	push ar4, gr4;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src1
+	ar3 = [--ar5] with gr4 = false; // src2 
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpLtV_f;
+    nul;
+    nul;
+
+	ar4 = gr4; 
+	sir = ar4, gr4;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpLtV_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpLtV_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src1
+	fpu 0 rep 32 vreg1 = [ar3++]; 						// читаем 64 элемента массива src2
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if <;
+	gr2--;
+	if > delayed goto CmpLtV_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpLtV_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpLtV_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 rep vlen vreg1 = [ar3++];
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if <;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpLtV_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	pop ar4, gr4;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpLteC_f.asm
+++ b/src_proc0/nm/cmpLteC_f.asm
@@ -1,0 +1,123 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+  dupC: long = 0hl;
+
+end ".data_demo3d";
+
+//void cmpLteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpLteC_f: label;
+
+begin ".text_demo3d"
+<_cmpLteC_f>
+	ar5 = ar7 - 2;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src
+	ar3 = [--ar5]; // C
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpLtC_f;
+    nul;
+    gr3 = ar3;
+
+  [dupC] = ar3,gr3;
+  ar3 = dupC with gr3 = false;
+
+	fpu 0 rep 1 vreg1 = [ar3];
+	ar3 = gr3;
+	sir = ar3, gr3;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpLtC_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpLtC_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if <=;
+	gr2--;
+	if > delayed goto CmpLtC_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpLtC_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpLtC_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if <=;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpLtC_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpLteC_f.asm
+++ b/src_proc0/nm/cmpLteC_f.asm
@@ -1,49 +1,6 @@
+extern shiftedZeroes: word;
 data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
   dupC: long = 0hl;
-
 end ".data_demo3d";
 
 //void cmpLteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);

--- a/src_proc0/nm/cmpLteV_f.asm
+++ b/src_proc0/nm/cmpLteV_f.asm
@@ -1,48 +1,4 @@
-data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
-end ".data_demo3d";
+extern shiftedZeroes: word;
 
 //void cmpLteV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 global _cmpLteV_f: label;

--- a/src_proc0/nm/cmpLteV_f.asm
+++ b/src_proc0/nm/cmpLteV_f.asm
@@ -1,0 +1,121 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+end ".data_demo3d";
+
+//void cmpLteV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpLteV_f: label;
+
+begin ".text_demo3d"
+<_cmpLteV_f>
+	ar5 = ar7 - 2;
+	push ar4, gr4;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src1
+	ar3 = [--ar5] with gr4 = false; // src2 
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpLteV_f;
+    nul;
+    nul;
+
+	ar4 = gr4; 
+	sir = ar4, gr4;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpLteV_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpLteV_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src1
+	fpu 0 rep 32 vreg1 = [ar3++]; 						// читаем 64 элемента массива src2
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if <=;
+	gr2--;
+	if > delayed goto CmpLteV_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpLteV_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpLteV_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 rep vlen vreg1 = [ar3++];
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if <=;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpLteV_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	pop ar4, gr4;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpNeC_f.asm
+++ b/src_proc0/nm/cmpNeC_f.asm
@@ -1,49 +1,6 @@
+extern shiftedZeroes: word;
 data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
   dupC: long = 0hl;
-
 end ".data_demo3d";
 
 //void cmpNeC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);

--- a/src_proc0/nm/cmpNeC_f.asm
+++ b/src_proc0/nm/cmpNeC_f.asm
@@ -1,0 +1,123 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+  dupC: long = 0hl;
+
+end ".data_demo3d";
+
+//void cmpNeC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpNeC_f: label;
+
+begin ".text_demo3d"
+<_cmpNeC_f>
+	ar5 = ar7 - 2;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src
+	ar3 = [--ar5]; // C
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpEqC_f;
+    nul;
+    gr3 = ar3;
+
+  [dupC] = ar3,gr3;
+  ar3 = dupC with gr3 = false;
+
+	fpu 0 rep 1 vreg1 = [ar3];
+	ar3 = gr3;
+	sir = ar3, gr3;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpEqC_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpEqC_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if <>0;
+	gr2--;
+	if > delayed goto CmpEqC_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpEqC_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpEqC_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 .float vreg2 = vreg0 - .retrive(vreg1), set mask if <>0;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpEqC_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpNeV_f.asm
+++ b/src_proc0/nm/cmpNeV_f.asm
@@ -1,0 +1,121 @@
+data ".data_demo3d"
+  shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+
+end ".data_demo3d";
+
+//void cmpNeV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+global _cmpNeV_f: label;
+
+begin ".text_demo3d"
+<_cmpNeV_f>
+	ar5 = ar7 - 2;
+	push ar4, gr4;
+	push ar3, gr3;
+	push ar2, gr2;
+	push ar1, gr1;
+	push ar0, gr0;
+
+	ar0 = [--ar5]; // src1
+	ar3 = [--ar5] with gr4 = false; // src2 
+	ar1 = [--ar5]; // dstMaskEven
+	ar2 = [--ar5]; // dstMaskOdd
+	gr1 = [--ar5]; // size
+  
+  with gr1;
+  if =0 delayed goto exit_CmpEqV_f;
+    nul;
+    nul;
+
+	ar4 = gr4; 
+	sir = ar4, gr4;
+	gr2 = gr1 >> 6; 
+	if =0 delayed goto less64_CmpEqV_f;
+		fp0_lmask = sir;
+		fp0_hmask = sir;
+
+
+<CmpEqV_f>
+	fpu 0 rep 32 vreg0 = [ar0++]; 						// читаем 64 элемента массива src1
+	fpu 0 rep 32 vreg1 = [ar3++]; 						// читаем 64 элемента массива src2
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if <>0;
+	gr2--;
+	if > delayed goto CmpEqV_f;
+		[ar1++] = fp0_lmask;
+		[ar2++] = fp0_hmask;
+
+	gr1 = gr1 << 26;									// вычисляем остаток
+	gr1 = gr1 >> 26;									// вычисляем остаток
+	if =0 delayed goto exit_CmpEqV_f;					// если остаток 0, значит обработаны все элементы
+    	fp0_lmask = sir;
+    	fp0_hmask = sir;
+<less64_CmpEqV_f>
+  gr3 = 1 with gr0 = gr1 - 1; //gr3 = 1 and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+  gr2 = gr1 with gr0 = gr0 >> 1; //remember residue count and calc vlen (count = gr1/2 - 1 = (gr1-1)/2, vlen = count - 1)
+	vlen = gr0;
+	fpu 0 rep vlen vreg0 = [ar0++];
+	fpu 0 rep vlen vreg1 = [ar3++];
+	fpu 0 .float vreg2 = vreg0 - vreg1, set mask if <>0;
+	[ar1++] = fp0_lmask; //write even mask immediately
+  
+  //odd mask require zeroing of last bit if residue count was odd 
+  gr2 and gr3;
+  if =0 delayed goto residueCountIsEven; //else - residue count is odd - need to zero last bit in odd mask
+    sir = fp0_hmask; 
+    gr1 = sir ;
+  ar0 = shiftedZeroes;
+  gr1 = sir;
+  gr2 = [ar0+gr0];
+  gr1 = gr1 and gr2;
+  sir = gr1;
+  fp0_hmask = sir;
+<residueCountIsEven>
+	[ar2++] = fp0_hmask;
+<exit_CmpEqV_f>
+	pop ar0, gr0;
+	pop ar1, gr1;
+	pop ar2, gr2;
+	pop ar3, gr3;
+	pop ar4, gr4;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cmpNeV_f.asm
+++ b/src_proc0/nm/cmpNeV_f.asm
@@ -1,48 +1,4 @@
-data ".data_demo3d"
-  shiftedZeroes: word[32] = ( 
-		0fffffffeh,
-		0fffffffdh,
-		0fffffffbh,
-		0fffffff7h,
-
-		0ffffffefh,
-		0ffffffdfh,
-		0ffffffbfh,
-		0ffffff7fh,
-
-		0fffffeffh,
-		0fffffdffh,
-		0fffffbffh,
-		0fffff7ffh,
-
-		0ffffefffh,
-		0ffffdfffh,
-		0ffffbfffh,
-		0ffff7fffh,
-
-		0fffeffffh,
-		0fffdffffh,
-		0fffbffffh,
-		0fff7ffffh,
-
-		0ffefffffh,
-		0ffdfffffh,
-		0ffbfffffh,
-		0ff7fffffh,
-
-		0feffffffh,
-		0fdffffffh,
-		0fbffffffh,
-		0f7ffffffh,
-
-		0efffffffh,
-		0dfffffffh,
-		0bfffffffh,
-		07fffffffh
-
-	);
-
-end ".data_demo3d";
+extern shiftedZeroes: word;
 
 //void cmpNeV_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 global _cmpNeV_f: label;

--- a/src_proc0/nm/cnvDividedMaskToIndices.asm
+++ b/src_proc0/nm/cnvDividedMaskToIndices.asm
@@ -1,0 +1,67 @@
+//int cnvDividedMaskToIndices(nm1* maskEven, nm1* maskOdd, int* indices, int size);
+//Based on readDividedMask. size must be odd for correct result.
+
+begin ".text_demo3d"
+global _cnvDividedMaskToIndices: label;
+<_cnvDividedMaskToIndices>
+	ar5 = sp - 2;
+	push ar0, gr0	with gr7 = false;
+	push ar1, gr1	with gr1 = false;
+	push ar2, gr2	with gr1++;
+	push ar3, gr3;
+	push ar4, gr4;
+	push ar5, gr5;
+	push ar6, gr6	with gr0 = gr7;
+	ar0 = [--ar5];
+	ar1 = [--ar5];
+	ar6 = [--ar5];
+	gr5 = [--ar5]	 with gr2 = gr1 << 5;
+	gr5 >>=1 ;
+	if =0 delayed goto EndProgram;	
+<NextWord>
+	gr3 = [ar0++];
+	gr4 = [ar1++];
+	gr3 or gr4;
+<EvenMask>
+  if =0 delayed goto EndWord;
+    gr0 - gr5;	
+    nul;
+  if >= delayed goto EndWord;
+    gr3 and gr1;	
+    nul;
+	if =0 delayed goto OddMask;
+    gr3 >>= 1;
+		gr4 and gr1;
+	gr0 <<= 1;
+	[ar6++] = gr0	with gr0 >>= 1;	//запись 2*i
+	gr7++;
+	gr4 and gr1;
+<OddMask>
+	if =0 delayed goto EndBit;
+		gr2--;
+		gr4 >>= 1;
+	gr0 <<= 1;
+	gr0++;
+	[ar6++] = gr0	with gr0>>=1;	//запись 2*i+1
+	gr7++;	
+<EndBit>
+	delayed goto EvenMask;
+		gr0++;
+		gr3 or gr4;
+<EndWord>
+	gr0 += gr2;
+	gr2 = gr1 << 5;
+	gr0 - gr5;
+	if < delayed goto NextWord;
+		nul;
+		nul;
+<EndProgram>
+	pop ar6, gr6;
+	pop ar5, gr5;
+	pop ar4, gr4;
+	pop ar3, gr3;
+	pop ar2, gr2;
+	pop ar1, gr1;
+	pop ar0, gr0;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cnvDividedMaskToOffsets.asm
+++ b/src_proc0/nm/cnvDividedMaskToOffsets.asm
@@ -1,0 +1,74 @@
+//int cnvDividedMaskToOffsets(nm1* maskEven, nm1* maskOdd, int* offsets, int size);
+//Based on readDividedMask. size must be odd for correct result.
+
+begin ".text_demo3d"
+global _cnvDividedMaskToOffsets: label;
+<_cnvDividedMaskToOffsets>
+	ar5 = sp - 2;
+	push ar0, gr0	with gr7 = false;
+	push ar1, gr1	with gr1 = false;
+	push ar2, gr2	with gr1++;
+	push ar3, gr3;
+	push ar4, gr4;
+	push ar5, gr5 with gr0 = gr7;
+	push ar6, gr6	with gr6 = false;
+	ar0 = [--ar5];
+	ar1 = [--ar5];
+	ar6 = [--ar5];
+	gr5 = [--ar5]	 with gr2 = gr1 << 5;
+	gr5 >>=1 ;
+	if =0 delayed goto End;	
+	gr3 = [ar0++];
+	gr4 = [ar1++];
+<NextWord>
+	gr3 or gr4;
+<EvenMask>
+	if =0 delayed goto EndWord;
+		gr0 - gr5;	
+		nul;
+	if >= delayed goto EndWord;
+		gr3 and gr1;	
+		nul;
+	if =0 delayed goto EvenMaskElse;
+		gr3 >>= 1;
+		gr4 and gr1;
+	[ar6++] = gr6	with gr6 = gr1;	
+	gr7++;
+	gr4 and gr1;
+<OddMask>
+	if =0 delayed goto OddMaskElse;
+		gr2--;
+		gr4 >>= 1;
+	[ar6++] = gr6	with gr6 = gr1;	
+	gr7++;	
+<EndBit>
+	delayed goto EvenMask;
+		gr0++;
+		gr3 or gr4;
+<EvenMaskElse>
+  delayed goto OddMask;
+    gr6++ noflags;
+    nul;
+<OddMaskElse>
+  delayed goto EndBit;
+    gr6++ noflags;
+    nul;
+<EndWord>
+	gr0 += gr2;
+  gr2 <<= 1;
+  gr6 += gr2; 
+	gr2 = gr1 << 5;
+	gr0 - gr5;
+	if < delayed goto NextWord;
+	  gr3 = [ar0++];
+	  gr4 = [ar1++];
+<End>
+	pop ar6, gr6;
+	pop ar5, gr5;
+	pop ar4, gr4;
+	pop ar3, gr3;
+	pop ar2, gr2;
+	pop ar1, gr1;
+	pop ar0, gr0;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cnvMaskToIndices.asm
+++ b/src_proc0/nm/cnvMaskToIndices.asm
@@ -1,0 +1,46 @@
+//int cnvMaskToIndices(nm1* mask, int* indices, int size)
+//Based on readMask 
+
+begin ".text_demo3d"
+global _cnvMaskToIndices: label;
+<_cnvMaskToIndices>
+	ar5 = sp - 2;
+	push ar0, gr0;
+	push ar1, gr1;
+	push ar2, gr2	with gr1 = false;
+	push ar5, gr5	with gr1++;
+	push ar6, gr6	with gr0 = false;
+	ar0 = [--ar5]	with gr6 = gr0;
+	ar6 = [--ar5];
+	gr5 = [--ar5];
+	
+	gr7 = [ar0++] with gr2 = gr1 << 5;
+	gr7;
+<NextBit>
+	if =0 delayed goto EndWord;
+		gr0 - gr5;	
+		nul;
+	if >= delayed goto EndWord;
+		gr7 and gr1;	
+		nul;
+	if =0 delayed goto NextBit	with gr0++;
+		gr2--;
+		gr7 >>= 1;
+	delayed goto NextBit with gr0-- noflags;
+		[ar6++] = gr0	with gr6++ noflags;
+		gr0++ noflags;
+<EndWord>
+	gr0 += gr2;
+	gr0 - gr5;
+	if < delayed goto NextBit;
+		gr7 = [ar0++] with gr2 = gr1 << 5;
+		gr7;
+<EndProgram>
+	with gr7 = gr6;
+	pop ar6, gr6;
+	pop ar5, gr5;
+	pop ar2, gr2;
+	pop ar1, gr1;
+	pop ar0, gr0;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/cnvMaskToOffsets.asm
+++ b/src_proc0/nm/cnvMaskToOffsets.asm
@@ -1,0 +1,51 @@
+//int cnvMaskToOffsets(nm1* mask, int* offsets, int size)
+//Based on readMask 
+
+begin ".text_demo3d"
+global _cnvMaskToOffsets: label;
+<_cnvMaskToOffsets>
+	ar5 = sp - 2;
+	push ar0, gr0;
+	push ar1, gr1;
+	push ar2, gr2	with gr1 = false;
+	push ar3, gr3 with gr1++;
+	push ar5, gr5	with gr0 = false;
+	push ar6, gr6 with gr3 = false;
+	ar0 = [--ar5]	with gr6 = gr0;
+	ar6 = [--ar5];
+	gr5 = [--ar5];
+	
+	gr7 = [ar0++] with gr2 = gr1 << 5;
+	gr7;
+<NextBit>
+	if =0 delayed goto EndWord;
+		gr0 - gr5;	
+		nul;
+	if >= delayed goto EndWord;
+		gr7 and gr1;	
+		nul;
+		gr3++ noflags;
+	if =0 delayed goto NextBit	with gr0++;
+		gr2--;
+		gr7 >>= 1;
+	delayed goto NextBit with gr3-- noflags;
+		[ar6++] = gr3	with gr6++ noflags;
+		gr3 = gr1;
+<EndWord>
+	gr0 += gr2;
+	gr3 += gr2;
+	gr0 - gr5;
+	if < delayed goto NextBit;
+		gr7 = [ar0++] with gr2 = gr1 << 5;
+		gr7;
+	gr1 = 1;
+<End>
+	with gr7 = gr6;
+	pop ar6, gr6;
+	pop ar5, gr5;
+	pop ar3, gr3;
+	pop ar2, gr2;
+	pop ar1, gr1;
+	pop ar0, gr0;
+	return;
+end ".text_demo3d";

--- a/src_proc0/nm/deselectElementsByIndices.asm
+++ b/src_proc0/nm/deselectElementsByIndices.asm
@@ -1,0 +1,52 @@
+//void deselectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size)
+//sizeOfElementInt must be < 2^26 to gr3*gr7 fit into word(32 bits)
+
+begin ".text_demo3d"
+global _deselectElementsByIndices: label;
+<_deselectElementsByIndices>
+  ar5 = sp - 2;
+  push ar0, gr0;
+  push ar1, gr1;
+  push ar2, gr2;
+  push ar3, gr3;
+  push ar4, gr4;
+  push ar5, gr5;
+  ar2 = [--ar5];
+  ar1 = [--ar5];
+  ar0 = [--ar5];
+  gr3 = [--ar5] with gr2=false;
+  gr1 = [--ar5] with gr4=false;
+
+  ar3 = ar0;
+<NextIndex>
+  gr2 - gr1;
+  if =0 delayed goto EndProgram;
+    ar0 = ar3;
+    gr7 = [ar1++]; 
+  with gr0 = gr3 *: gr7; //gr3 = sizeOfElementInt. 
+.repeat 15;
+  with gr0 = gr3 * gr7;
+.endrepeat;
+  gr0 = gr7; //gr7 contains lower 32 bits of multiplication
+  ar0 = ar0 + gr0;
+  gr4 - gr3;
+<NextInt>
+    if =0 delayed goto AllIntsProcessed;
+      gr4++; 
+      gr4 - gr3; 
+    delayed goto NextInt;
+      gr5 = [ar2++]; 
+      [ar0++] = gr5; 
+<AllIntsProcessed>
+  delayed goto NextIndex;
+    gr4 = false; 
+    gr2++; 
+<EndProgram>
+  pop ar5, gr5;
+  pop ar4, gr4;
+  pop ar3, gr3;
+  pop ar2, gr2;
+  pop ar1, gr1;
+  pop ar0, gr0;
+return;
+end ".text_demo3d";

--- a/src_proc0/nm/selectElementsByIndices.asm
+++ b/src_proc0/nm/selectElementsByIndices.asm
@@ -1,0 +1,52 @@
+//void selectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size)
+//sizeOfElementInt must be < 2^26 to gr3*gr7 fit into word(32 bits)
+
+begin ".text_demo3d"
+global _selectElementsByIndices: label;
+<_selectElementsByIndices>
+  ar5 = sp - 2;
+  push ar0, gr0;
+  push ar1, gr1;
+  push ar2, gr2;
+  push ar3, gr3;
+  push ar4, gr4;
+  push ar5, gr5;
+  ar0 = [--ar5];
+  ar1 = [--ar5];
+  ar2 = [--ar5];
+  gr3 = [--ar5] with gr2=false;
+  gr1 = [--ar5] with gr4=false;
+
+  ar3 = ar0;
+<NextIndex>
+  gr2 - gr1;
+  if =0 delayed goto EndProgram;
+    ar0 = ar3;
+    gr7 = [ar1++]; 
+  with gr0 = gr3 *: gr7; //gr3 = sizeOfElementInt. 
+.repeat 15;
+  with gr0 = gr3 * gr7;
+.endrepeat;
+  gr0 = gr7; //gr7 contains lower 32 bits of multiplication
+  ar0 = ar0 + gr0;
+  gr4 - gr3;
+<NextInt>
+    if =0 delayed goto AllIntsProcessed;
+      gr4++; 
+      gr4 - gr3; 
+    delayed goto NextInt;
+      gr5 = [ar0++]; 
+      [ar2++] = gr5; 
+<AllIntsProcessed>
+  delayed goto NextIndex;
+    gr4 = false; 
+    gr2++; 
+<EndProgram>
+  pop ar5, gr5;
+  pop ar4, gr4;
+  pop ar3, gr3;
+  pop ar2, gr2;
+  pop ar1, gr1;
+  pop ar0, gr0;
+return;
+end ".text_demo3d";

--- a/src_proc0/nm/selectElementsByOffsets.asm
+++ b/src_proc0/nm/selectElementsByOffsets.asm
@@ -1,0 +1,51 @@
+//void selectElementsByOffsets(void* src, int* offsets, void* dst, int sizeOfElementInt, int size)
+//sizeOfElementInt must be < 2^26 to gr3*gr7 fit into word(32 bits)
+
+begin ".text_demo3d"
+global _selectElementsByOffsets: label;
+<_selectElementsByOffsets>
+  ar5 = sp - 2;
+  push ar0, gr0;
+  push ar1, gr1;
+  push ar2, gr2;
+  push ar3, gr3;
+  push ar4, gr4;
+  push ar5, gr5;
+  ar0 = [--ar5];
+  ar1 = [--ar5];
+  ar2 = [--ar5];
+  gr3 = [--ar5] with gr2=false;
+  gr1 = [--ar5] with gr4=false;
+
+<NextOffset>
+  gr2 - gr1;
+  if =0 delayed goto EndProgram;
+    gr7 = [ar1++]; 
+    with gr0 = gr3 *: gr7; //gr3 = sizeOfElementInt 
+.repeat 15;
+  with gr0 = gr3 * gr7;
+.endrepeat;
+  gr0 = gr7; //gr7 contains lower 32 bits of multiplication
+  ar0 = ar0 + gr0;
+<NextInt>
+    gr4 - gr3;
+    if =0 delayed goto AllIntsProcessed;
+      gr0 = -gr3; 
+      gr4++; 
+    delayed goto NextInt;
+      gr5 = [ar0++]; 
+      [ar2++] = gr5; 
+<AllIntsProcessed>
+  ar0 = ar0 + gr0;
+  delayed goto NextOffset;
+    gr4 = false; 
+    gr2++; 
+<EndProgram>
+  pop ar5, gr5;
+  pop ar4, gr4;
+  pop ar3, gr3;
+  pop ar2, gr2;
+  pop ar1, gr1;
+  pop ar0, gr0;
+return;
+end ".text_demo3d";

--- a/src_proc0/nm/shiftedZeroes.asm
+++ b/src_proc0/nm/shiftedZeroes.asm
@@ -1,0 +1,44 @@
+data ".data_demo3d"
+  global shiftedZeroes: word[32] = ( 
+		0fffffffeh,
+		0fffffffdh,
+		0fffffffbh,
+		0fffffff7h,
+
+		0ffffffefh,
+		0ffffffdfh,
+		0ffffffbfh,
+		0ffffff7fh,
+
+		0fffffeffh,
+		0fffffdffh,
+		0fffffbffh,
+		0fffff7ffh,
+
+		0ffffefffh,
+		0ffffdfffh,
+		0ffffbfffh,
+		0ffff7fffh,
+
+		0fffeffffh,
+		0fffdffffh,
+		0fffbffffh,
+		0fff7ffffh,
+
+		0ffefffffh,
+		0ffdfffffh,
+		0ffbfffffh,
+		0ff7fffffh,
+
+		0feffffffh,
+		0fdffffffh,
+		0fbffffffh,
+		0f7ffffffh,
+
+		0efffffffh,
+		0dfffffffh,
+		0bfffffffh,
+		07fffffffh
+
+	);
+end ".data_demo3d";

--- a/src_proc0/pc/cmpEqC_f.cpp
+++ b/src_proc0/pc/cmpEqC_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpEqC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src[i] == C ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpEqV_f.cpp
+++ b/src_proc0/pc/cmpEqV_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpEqV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src1[i] == src2[i] ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpGtC_f.cpp
+++ b/src_proc0/pc/cmpGtC_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpGtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src[i] > C ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpGtV_f.cpp
+++ b/src_proc0/pc/cmpGtV_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpGtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src1[i] > src2[i] ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpGteC_f.cpp
+++ b/src_proc0/pc/cmpGteC_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpGteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src[i] >= C ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpGteV_f.cpp
+++ b/src_proc0/pc/cmpGteV_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpGteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src1[i] >= src2[i] ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpLtC_f.cpp
+++ b/src_proc0/pc/cmpLtC_f.cpp
@@ -1,0 +1,37 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpLtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src[i] < C ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+}
+  

--- a/src_proc0/pc/cmpLtV_f.cpp
+++ b/src_proc0/pc/cmpLtV_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpLtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src1[i] < src2[i] ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpLteC_f.cpp
+++ b/src_proc0/pc/cmpLteC_f.cpp
@@ -1,0 +1,37 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpLteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src[i] <= C ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+}
+  

--- a/src_proc0/pc/cmpLteV_f.cpp
+++ b/src_proc0/pc/cmpLteV_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpLteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src1[i] <= src2[i] ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpNeC_f.cpp
+++ b/src_proc0/pc/cmpNeC_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpNeC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src[i] != C ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cmpNeV_f.cpp
+++ b/src_proc0/pc/cmpNeV_f.cpp
@@ -1,0 +1,38 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+#include "nmpp.h"
+
+extern "C"{
+
+void cmpNeV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size) {
+
+  unsigned int i = 0;
+
+  if (size <= 0) return;
+
+  for (i=0; i<size; i++) {
+    int compRes = src1[i] != src2[i] ? 1 : 0;
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, compRes);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, compRes);
+    }
+  }
+
+  unsigned int residue = (i<<26)>>26;
+  if (residue == 0) return;
+  residue = 64 - residue;
+  unsigned int curIndex = i;
+  for ( i=curIndex; i<curIndex + residue; i++) {
+    if (i&1){
+      nmppsPut_1(dstMaskOdd, i>>1, 0);
+    } else {
+      nmppsPut_1(dstMaskEven, i>>1, 0);
+    }
+  }
+
+}
+
+}
+  

--- a/src_proc0/pc/cnvDividedMaskToIndices.cpp
+++ b/src_proc0/pc/cnvDividedMaskToIndices.cpp
@@ -1,0 +1,41 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+
+extern "C"{
+int cnvDividedMaskToIndices(nm1* maskEven, nm1* maskOdd, int* indices, int size) {
+
+#ifdef DEBUG
+  if ((size < 0) || ((size & 1) != 0)) {
+    printf ("%s:%d: Error: size must be non negative even number", __FILE__, __LINE__);
+  }
+#endif //DEBUG
+
+	int result = 0;
+	int i = 0;
+	int i32 = 0;
+	int* maskVecEven = ((int*)maskEven);
+	int* maskVecOdd = ((int*)maskOdd);
+	size /= 2;
+	while (i < size) {
+		unsigned int tmpMaskEven = maskVecEven[i32];
+		unsigned int tmpMaskOdd = maskVecOdd[i32];
+		i32++;
+		unsigned int remainingBits = 32;
+		while ((tmpMaskEven | tmpMaskOdd) && (i < size)) {
+			if (tmpMaskEven & 1) {
+				indices[result++] = 2 * i;
+			}
+			if (tmpMaskOdd & 1) {
+				indices[result++] = 2 * i + 1;
+			}
+			i++;
+			tmpMaskEven >>= 1;
+			tmpMaskOdd >>= 1;
+			remainingBits--;
+		}
+		i += remainingBits;
+	}
+	return result;
+}
+}

--- a/src_proc0/pc/cnvDividedMaskToOffsets.cpp
+++ b/src_proc0/pc/cnvDividedMaskToOffsets.cpp
@@ -1,0 +1,51 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+#include "stdio.h"
+
+extern "C"{
+int cnvDividedMaskToOffsets(nm1* maskEven, nm1* maskOdd, int* offsets, int size){
+
+#ifdef DEBUG
+  if ((size < 0) || ((size & 1) != 0)) {
+    printf ("%s:%d: Error: size must be non negative even number", __FILE__, __LINE__);
+  }
+#endif //DEBUG
+
+	int result = 0;
+	int i = 0;
+	int i32 = 0;
+  int offset = 0;
+	int* maskVecEven = ((int*)maskEven);
+	int* maskVecOdd = ((int*)maskOdd);
+	size /= 2;
+	while (i < size) {
+		unsigned int tmpMaskEven = maskVecEven[i32];
+		unsigned int tmpMaskOdd = maskVecOdd[i32];
+		i32++;
+		unsigned int remainingBits = 32;
+		while ((tmpMaskEven | tmpMaskOdd) && (i < size)) {
+			if (tmpMaskEven & 1) {
+				offsets[result++] = offset;
+        offset = 1;
+			}
+      else {
+        offset++;
+      }
+			if (tmpMaskOdd & 1) {
+				offsets[result++] = offset;
+        offset = 1;
+			}
+      else {
+        offset++;
+      }
+			i++;
+			tmpMaskEven >>= 1;
+			tmpMaskOdd >>= 1;
+			remainingBits--;
+		}
+		i += remainingBits;
+    offset += remainingBits*2; 
+	}
+	return result;
+}
+}

--- a/src_proc0/pc/cnvMaskToIndices.cpp
+++ b/src_proc0/pc/cnvMaskToIndices.cpp
@@ -1,0 +1,27 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+
+extern "C" 
+SECTION(".text_demo3d")
+int cnvMaskToIndices(nm1* mask, int* indices, int size){
+  int result = 0;
+	int i = 0;
+	int i32 = 0;
+	int* maskVec = ((int*)mask);
+
+	while (i < size) {
+		unsigned int tmpMask = maskVec[i32++];
+		unsigned int remainingBits = 32;
+		while (tmpMask && (i < size)) {
+			if (tmpMask & 1) {
+				indices[result++] = i;
+			}
+			i++;
+			tmpMask >>= 1;
+			remainingBits--;
+		}
+		i += remainingBits;
+	}
+
+	return result;
+}

--- a/src_proc0/pc/cnvMaskToOffsets.cpp
+++ b/src_proc0/pc/cnvMaskToOffsets.cpp
@@ -1,0 +1,30 @@
+#include "nmtype.h"
+#include "demo3d_common.h"
+
+extern "C" 
+SECTION(".text_demo3d")
+int cnvMaskToOffsets(nm1* mask, int* offsets, int size){
+  int result = 0;
+	int i = 0;
+	int offset = 0;
+	int i32 = 0;
+	int* maskVec = ((int*)mask);
+
+	while (i < size) {
+		unsigned int tmpMask = maskVec[i32++];
+		unsigned int remainingBits = 32;
+		while (tmpMask && (i < size)) {
+			if (tmpMask & 1) {
+				offsets[result++] = offset;
+				offset = 0;
+			}
+			i++;
+			offset++;
+			tmpMask >>= 1;
+			remainingBits--;
+		}
+		i += remainingBits;
+	}
+
+	return result;
+}

--- a/src_proc0/pc/deselectElementsByIndices.cpp
+++ b/src_proc0/pc/deselectElementsByIndices.cpp
@@ -1,0 +1,14 @@
+extern "C" {
+  void deselectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size) {
+
+    int* curSrcPos = (int*)src;
+    int* curDstPos = (int*)dst;
+    for (int i=0; i<size; i++) {
+      curDstPos = (int*)dst + indices[i]*sizeOfElementInt;
+      for (int j=0; j<sizeOfElementInt; j++) {
+        curDstPos[j] = curSrcPos[j];
+      }
+      curSrcPos = curSrcPos + sizeOfElementInt;
+    }
+  }
+}

--- a/src_proc0/pc/selectElementsByIndices.cpp
+++ b/src_proc0/pc/selectElementsByIndices.cpp
@@ -1,0 +1,14 @@
+extern "C" {
+  void selectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size) {
+
+    int* curSrcPos = (int*)src;
+    int* curDstPos = (int*)dst;
+    for (int i=0; i<size; i++) {
+      curSrcPos = (int*)src + indices[i]*sizeOfElementInt;
+      for (int j=0; j<sizeOfElementInt; j++) {
+        curDstPos[j] = curSrcPos[j];
+      }
+      curDstPos = curDstPos + sizeOfElementInt;
+    }
+  }
+}

--- a/src_proc0/pc/selectElementsByOffsets.cpp
+++ b/src_proc0/pc/selectElementsByOffsets.cpp
@@ -1,0 +1,14 @@
+extern "C" {
+  void selectElementsByOffsets(void* src, int* offsets, void* dst, int sizeOfElementInt, int size) {
+
+    int* curSrcPos = (int*)src;
+    int* curDstPos = (int*)dst;
+    for (int i=0; i<size; i++) {
+      curSrcPos = curSrcPos + offsets[i]*sizeOfElementInt;
+      for (int j=0; j<sizeOfElementInt; j++) {
+        curDstPos[j] = curSrcPos[j];
+      }
+      curDstPos = curDstPos + sizeOfElementInt;
+    }
+  }
+}

--- a/test/nmpu0/cmpEqC_f/main.cpp
+++ b/test/nmpu0/cmpEqC_f/main.cpp
@@ -16,6 +16,7 @@ int cmpEqC_f_size69_resultCorrect();
 int cmpEqC_f_evenEqual_maskCorrect();
 int cmpEqC_f_oddEqual_maskCorrect();
 int cmpEqC_f_comparisonTest_maskCorrect();
+int cmpEqC_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpEqC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpEqC_f_evenEqual_maskCorrect);
 	  RUN_TEST(cmpEqC_f_oddEqual_maskCorrect);
 	  RUN_TEST(cmpEqC_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpEqC_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -335,5 +337,70 @@ int cmpEqC_f_comparisonTest_maskCorrect(){
   TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
   TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
 
+  return 0;
+}
+
+//Check that function does not change dstMasks more than it is needed
+int cmpEqC_f_size69_dstMaskExtraWordsNotChanged(){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  float src[srcSize] = {0};
+  constexpr int size = 69;
+  float C = 1.0;
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
   return 0;
 }

--- a/test/nmpu0/cmpEqC_f/main.cpp
+++ b/test/nmpu0/cmpEqC_f/main.cpp
@@ -1,0 +1,339 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpEqC_f_size0_resultCorrect();
+int cmpEqC_f_size1_resultCorrect();
+int cmpEqC_f_size63_resultCorrect();
+int cmpEqC_f_size64_resultCorrect();
+int cmpEqC_f_size68_resultCorrect();
+int cmpEqC_f_size69_resultCorrect();
+int cmpEqC_f_evenEqual_maskCorrect();
+int cmpEqC_f_oddEqual_maskCorrect();
+int cmpEqC_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpEqC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpEqC_f_size0_resultCorrect);
+	  RUN_TEST(cmpEqC_f_size1_resultCorrect);
+	  RUN_TEST(cmpEqC_f_size63_resultCorrect);
+	  RUN_TEST(cmpEqC_f_size64_resultCorrect);
+	  RUN_TEST(cmpEqC_f_size68_resultCorrect);
+	  RUN_TEST(cmpEqC_f_size69_resultCorrect);
+	  RUN_TEST(cmpEqC_f_evenEqual_maskCorrect);
+	  RUN_TEST(cmpEqC_f_oddEqual_maskCorrect);
+	  RUN_TEST(cmpEqC_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpEqC_f_size0_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqC_f_size1_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpEqC_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpEqC_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpEqC_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i=i+2) {
+    src[i] = 0.0;
+  }
+  for (int i=1; i<size; i=i+2) {
+    src[i] = 2.0;
+  }
+  src[4] = 1.0;
+  src[7] = 1.0;
+  src[64] = 1.0;
+  src[67] = 1.0;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqC_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i=i+2) {
+    src[i] = 0.0;
+  }
+  for (int i=1; i<size; i=i+2) {
+    src[i] = 2.0;
+  }
+  src[4] = 1.0;
+  src[7] = 1.0;
+  src[64] = 1.0;
+  src[67] = 1.0;
+  src[68] = 1.0;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqC_f_evenEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0.5,0,0.5,1,0.5,0,0.5,1, 0.5,0,0.5,1,0.5,0,0.5,1, 0.5,0,0.5,1,0.5,0,0.5,1, 0.5,0,0.5,1,0.5,0,0.5,1, 0.5,0,0.5,0.5};
+  float C = 0.5;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqC_f_oddEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,0.5,0.5};
+  float C = 0.5;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqC_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                          -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                       -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                 0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                 };
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x000050a0};
+  unsigned int refDstMaskOdd[] ={0x0000050a};  
+  int resMaskCount = 1;
+
+  cmpEqC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpEqV_f/main.cpp
+++ b/test/nmpu0/cmpEqV_f/main.cpp
@@ -1,0 +1,355 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpEqV_f_size0_resultCorrect();
+int cmpEqV_f_size1_resultCorrect();
+int cmpEqV_f_size63_resultCorrect();
+int cmpEqV_f_size64_resultCorrect();
+int cmpEqV_f_size68_resultCorrect();
+int cmpEqV_f_size69_resultCorrect();
+int cmpEqV_f_evenEqual_maskCorrect();
+int cmpEqV_f_oddEqual_maskCorrect();
+int cmpEqV_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpEqV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpEqV_f_size0_resultCorrect);
+	  RUN_TEST(cmpEqV_f_size1_resultCorrect);
+	  RUN_TEST(cmpEqV_f_size63_resultCorrect);
+	  RUN_TEST(cmpEqV_f_size64_resultCorrect);
+	  RUN_TEST(cmpEqV_f_size68_resultCorrect);
+	  RUN_TEST(cmpEqV_f_size69_resultCorrect);
+	  RUN_TEST(cmpEqV_f_evenEqual_maskCorrect);
+	  RUN_TEST(cmpEqV_f_oddEqual_maskCorrect);
+	  RUN_TEST(cmpEqV_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpEqV_f_size0_resultCorrect(){
+
+  float src1[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float src2[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqV_f_size1_resultCorrect(){
+
+  float src1[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float src2[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpEqV_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpEqV_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpEqV_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i=i+2) {
+    src1[i] = 0.0;
+  }
+  for (int i=1; i<size; i=i+2) {
+    src1[i] = 2.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 1.0;
+  src1[64] = 1.0;
+  src1[67] = 1.0;
+
+  for (int i=0; i<size; i=i+1) {
+    src2[i] = 1.0;
+  }
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqV_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i=i+2) {
+    src1[i] = 0.0;
+  }
+  for (int i=1; i<size; i=i+2) {
+    src1[i] = 2.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 1.0;
+  src1[64] = 1.0;
+  src1[67] = 1.0;
+  src1[68] = 1.0;
+
+  for (int i=0; i<size; i=i+1) {
+    src2[i] = 1.0;
+  }
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqV_f_evenEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5};
+  float src2[size+2] = {0.5,  0,0.5,  1,0.5,  0,0.5,  1, 0.5,  0,0.5,  1,0.5,  0,0.5,  1, 0.5,  0,0.5,  1,0.5,  0,0.5,  1, 0.5,  0,0.5,  1,0.5,  0,0.5,  1, 0.5,  0,0.5,0.5};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqV_f_oddEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,};
+  float src2[size+2] = {  0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,0.5,0.5,};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpEqV_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src1[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                               -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                            -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                      0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                     };
+  float src2[size] = {0.0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x000050a0};
+  unsigned int refDstMaskOdd[] ={0x0000050a};  
+  int resMaskCount = 1;
+
+  cmpEqV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpGtC_f/main.cpp
+++ b/test/nmpu0/cmpGtC_f/main.cpp
@@ -16,6 +16,7 @@ int cmpGtC_f_size69_resultCorrect();
 int cmpGtC_f_evenGreater_maskCorrect();
 int cmpGtC_f_oddGreater_maskCorrect();
 int cmpGtC_f_comparisonTest_maskCorrect();
+int cmpGtC_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpGtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpGtC_f_evenGreater_maskCorrect);
 	  RUN_TEST(cmpGtC_f_oddGreater_maskCorrect);
 	  RUN_TEST(cmpGtC_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpGtC_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -329,5 +331,71 @@ int cmpGtC_f_comparisonTest_maskCorrect(){
   TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
   TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
 
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpGtC_f_size69_dstMaskExtraWordsNotChanged(){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  float src[srcSize] = {0};
+  constexpr int size = 69;
+  float C = 0.0;
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
   return 0;
 }

--- a/test/nmpu0/cmpGtC_f/main.cpp
+++ b/test/nmpu0/cmpGtC_f/main.cpp
@@ -1,0 +1,333 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpGtC_f_size0_resultCorrect();
+int cmpGtC_f_size1_resultCorrect();
+int cmpGtC_f_size63_resultCorrect();
+int cmpGtC_f_size64_resultCorrect();
+int cmpGtC_f_size68_resultCorrect();
+int cmpGtC_f_size69_resultCorrect();
+int cmpGtC_f_evenGreater_maskCorrect();
+int cmpGtC_f_oddGreater_maskCorrect();
+int cmpGtC_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpGtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpGtC_f_size0_resultCorrect);
+	  RUN_TEST(cmpGtC_f_size1_resultCorrect);
+	  RUN_TEST(cmpGtC_f_size63_resultCorrect);
+	  RUN_TEST(cmpGtC_f_size64_resultCorrect);
+	  RUN_TEST(cmpGtC_f_size68_resultCorrect);
+	  RUN_TEST(cmpGtC_f_size69_resultCorrect);
+	  RUN_TEST(cmpGtC_f_evenGreater_maskCorrect);
+	  RUN_TEST(cmpGtC_f_oddGreater_maskCorrect);
+	  RUN_TEST(cmpGtC_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpGtC_f_size0_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtC_f_size1_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGtC_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGtC_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGtC_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+  src[4] = 1.0;
+  src[7] = 1.0;
+  src[64] = 1.0;
+  src[67] = 1.0;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtC_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+  src[4] = 1.0;
+  src[7] = 1.0;
+  src[64] = 1.0;
+  src[67] = 1.0;
+  src[68] = 1.0;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtC_f_evenGreater_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {2,0,2,1,2,0,2,1, 2,0,2,1,2,0,2,1, 2,0,2,1,2,0,2,1, 2,0,2,1,2,0,2,1, 2,0,2,2};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtC_f_oddGreater_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0,2,1,2,0,2,1,2, 0,2,1,2,0,2,1,2, 0,2,1,2,0,2,1,2, 0,2,1,2,0,2,1,2, 0,2,2,2};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtC_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                              -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                           -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                    };
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0000264C};
+  unsigned int refDstMaskOdd[] ={0x0003264};  
+  int resMaskCount = 1;
+
+  cmpGtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpGtV_f/main.cpp
+++ b/test/nmpu0/cmpGtV_f/main.cpp
@@ -16,6 +16,7 @@ int cmpGtV_f_size69_resultCorrect();
 int cmpGtV_f_evenGreater_maskCorrect();
 int cmpGtV_f_oddGreater_maskCorrect();
 int cmpGtV_f_comparisonTest_maskCorrect();
+int cmpGtV_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpGtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpGtV_f_evenGreater_maskCorrect);
 	  RUN_TEST(cmpGtV_f_oddGreater_maskCorrect);
 	  RUN_TEST(cmpGtV_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpGtV_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -335,6 +337,73 @@ int cmpGtV_f_comparisonTest_maskCorrect(){
   for (int i=0; i<size; i++) {
     src2[i] = 0.0;
   }
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+//Check that function does not change dstMasks more than it is needed
+int cmpGtV_f_size69_dstMaskExtraWordsNotChanged (){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  constexpr int size = 69;
+  float src1[srcSize] = {0};
+  float src2[srcSize] = {0};
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src1[i] = 1.0;
+    src2[i] = 0.0;
+  }
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
 
   cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
 

--- a/test/nmpu0/cmpGtV_f/main.cpp
+++ b/test/nmpu0/cmpGtV_f/main.cpp
@@ -1,0 +1,355 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpGtV_f_size0_resultCorrect();
+int cmpGtV_f_size1_resultCorrect();
+int cmpGtV_f_size63_resultCorrect();
+int cmpGtV_f_size64_resultCorrect();
+int cmpGtV_f_size68_resultCorrect();
+int cmpGtV_f_size69_resultCorrect();
+int cmpGtV_f_evenGreater_maskCorrect();
+int cmpGtV_f_oddGreater_maskCorrect();
+int cmpGtV_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpGtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpGtV_f_size0_resultCorrect);
+	  RUN_TEST(cmpGtV_f_size1_resultCorrect);
+	  RUN_TEST(cmpGtV_f_size63_resultCorrect);
+	  RUN_TEST(cmpGtV_f_size64_resultCorrect);
+	  RUN_TEST(cmpGtV_f_size68_resultCorrect);
+	  RUN_TEST(cmpGtV_f_size69_resultCorrect);
+	  RUN_TEST(cmpGtV_f_evenGreater_maskCorrect);
+	  RUN_TEST(cmpGtV_f_oddGreater_maskCorrect);
+	  RUN_TEST(cmpGtV_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpGtV_f_size0_resultCorrect(){
+
+  float src1[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float src2[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtV_f_size1_resultCorrect(){
+
+  float src1[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float src2[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGtV_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGtV_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGtV_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  src1[4] = 1.0;
+  src1[7] = 1.0;
+  src1[64] = 1.0;
+  src1[67] = 1.0;
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtV_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  src1[4] = 1.0;
+  src1[7] = 1.0;
+  src1[64] = 1.0;
+  src1[67] = 1.0;
+  src1[68] = 1.0;
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtV_f_evenGreater_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {2,3,2,4,2,3,2,4, 2,3,2,4,2,3,2,4, 2,3,2,4,2,3,2,4, 2,3,2,4,2,3,2,4, 2,3,2,2};
+  float src2[size+2] = {1,3,1,4,1,3,1,4, 1,3,1,4,1,3,1,4, 1,3,1,4,1,3,1,4, 1,3,1,4,1,3,1,4, 1,3,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtV_f_oddGreater_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {3,2,4,2,3,2,4,2, 3,2,4,2,3,2,4,2, 3,2,4,2,3,2,4,2, 3,2,4,2,3,2,4,2, 3,2,2,2};
+  float src2[size+2] = {3,1,4,1,3,1,4,1, 3,1,4,1,3,1,4,1, 3,1,4,1,3,1,4,1, 3,1,4,1,3,1,4,1, 3,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGtV_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src1[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                               -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                            -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                      0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                     };
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0000264C};
+  unsigned int refDstMaskOdd[] ={0x0003264};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpGtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpGteC_f/main.cpp
+++ b/test/nmpu0/cmpGteC_f/main.cpp
@@ -16,6 +16,7 @@ int cmpGteC_f_size69_resultCorrect();
 int cmpGteC_f_evenGreaterEqual_maskCorrect();
 int cmpGteC_f_oddGreaterEqual_maskCorrect();
 int cmpGteC_f_comparisonTest_maskCorrect();
+int cmpGteC_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpGteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpGteC_f_evenGreaterEqual_maskCorrect);
 	  RUN_TEST(cmpGteC_f_oddGreaterEqual_maskCorrect);
 	  RUN_TEST(cmpGteC_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpGteC_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -336,5 +338,71 @@ int cmpGteC_f_comparisonTest_maskCorrect(){
   TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
   TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
 
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpGteC_f_size69_dstMaskExtraWordsNotChanged(){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  float src[srcSize] = {0};
+  constexpr int size = 69;
+  float C = 0.0;
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
   return 0;
 }

--- a/test/nmpu0/cmpGteC_f/main.cpp
+++ b/test/nmpu0/cmpGteC_f/main.cpp
@@ -1,0 +1,340 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpGteC_f_size0_resultCorrect();
+int cmpGteC_f_size1_resultCorrect();
+int cmpGteC_f_size63_resultCorrect();
+int cmpGteC_f_size64_resultCorrect();
+int cmpGteC_f_size68_resultCorrect();
+int cmpGteC_f_size69_resultCorrect();
+int cmpGteC_f_evenGreaterEqual_maskCorrect();
+int cmpGteC_f_oddGreaterEqual_maskCorrect();
+int cmpGteC_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpGteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpGteC_f_size0_resultCorrect);
+	  RUN_TEST(cmpGteC_f_size1_resultCorrect);
+	  RUN_TEST(cmpGteC_f_size63_resultCorrect);
+	  RUN_TEST(cmpGteC_f_size64_resultCorrect);
+	  RUN_TEST(cmpGteC_f_size68_resultCorrect);
+	  RUN_TEST(cmpGteC_f_size69_resultCorrect);
+	  RUN_TEST(cmpGteC_f_evenGreaterEqual_maskCorrect);
+	  RUN_TEST(cmpGteC_f_oddGreaterEqual_maskCorrect);
+	  RUN_TEST(cmpGteC_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpGteC_f_size0_resultCorrect(){
+
+  float src[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteC_f_size1_resultCorrect(){
+
+  float src[] = {2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGteC_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[1] = {0xffffffff};
+  unsigned int dstMaskOdd[1] ={0xffffffff};  
+  unsigned int refDstMaskEven[1] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[1] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src[i] = 2.0;
+  }
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  printf ("%d\r\n", dstMaskEven);
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGteC_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[1] = {0x00000000};
+  unsigned int dstMaskOdd[1] ={0x00000000};  
+  unsigned int refDstMaskEven[1] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[1] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src[i] = 2.0;
+  }
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGteC_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+  src[4] = 1.0;
+  src[7] = 2.0;
+  src[64] = 2.0;
+  src[67] = 1.0;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteC_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+  src[4] = 1.0;
+  src[7] = 2.0;
+  src[64] = 2.0;
+  src[67] = 1.0;
+  src[68] = 1.0;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteC_f_evenGreaterEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {2,0,1,0,2,0,1,0, 2,0,1,0,2,0,1,0, 2,0,1,0,2,0,1,0, 2,0,1,0,2,0,1,0, 2,0,1,2};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteC_f_oddGreaterEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0,2,0,1,0,2,0,1, 0,2,0,1,0,2,0,1, 0,2,0,1,0,2,0,1, 0,2,0,1,0,2,0,1, 0,2,1,2};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteC_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                              -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                           -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                    };
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x000076ec};
+  unsigned int refDstMaskOdd[] ={0x000376e};  
+  int resMaskCount = 1;
+
+  cmpGteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpGteV_f/main.cpp
+++ b/test/nmpu0/cmpGteV_f/main.cpp
@@ -1,0 +1,357 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpGteV_f_size0_resultCorrect();
+int cmpGteV_f_size1_resultCorrect();
+int cmpGteV_f_size63_resultCorrect();
+int cmpGteV_f_size64_resultCorrect();
+int cmpGteV_f_size68_resultCorrect();
+int cmpGteV_f_size69_resultCorrect();
+int cmpGteV_f_evenGreaterEqual_maskCorrect();
+int cmpGteV_f_oddGreaterEqual_maskCorrect();
+int cmpGteV_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpGteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpGteV_f_size0_resultCorrect);
+	  RUN_TEST(cmpGteV_f_size1_resultCorrect);
+	  RUN_TEST(cmpGteV_f_size63_resultCorrect);
+	  RUN_TEST(cmpGteV_f_size64_resultCorrect);
+	  RUN_TEST(cmpGteV_f_size68_resultCorrect);
+	  RUN_TEST(cmpGteV_f_size69_resultCorrect);
+	  RUN_TEST(cmpGteV_f_evenGreaterEqual_maskCorrect);
+	  RUN_TEST(cmpGteV_f_oddGreaterEqual_maskCorrect);
+	  RUN_TEST(cmpGteV_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpGteV_f_size0_resultCorrect(){
+
+  float src1[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float src2[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteV_f_size1_resultCorrect(){
+
+  float src1[] = {2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1};
+  float src2[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGteV_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[1] = {0xffffffff};
+  unsigned int dstMaskOdd[1] ={0xffffffff};  
+  unsigned int refDstMaskEven[1] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[1] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src1[i] = 2.0;
+  }
+
+  for (int i=0; i<size; i=i+1) {
+    src2[i] = 1.0;
+  }
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  printf ("%d\r\n", dstMaskEven);
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGteV_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[1] = {0x00000000};
+  unsigned int dstMaskOdd[1] ={0x00000000};  
+  unsigned int refDstMaskEven[1] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[1] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src1[i] = 2.0;
+  }
+
+  for (int i=0; i<size; i=i+1) {
+    src2[i] = 1.0;
+  }
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpGteV_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 2.0;
+  src1[64] = 2.0;
+  src1[67] = 1.0;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteV_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 2.0;
+  src1[64] = 2.0;
+  src1[67] = 1.0;
+  src1[68] = 1.0;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteV_f_evenGreaterEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {2,3,1,3,2,3,1,3, 2,3,1,3,2,3,1,3, 2,3,1,3,2,3,1,3, 2,3,1,3,2,3,1,3, 2,3,1,2};
+  float src2[size+2] = {1,4,1,4,1,4,1,4, 1,4,1,4,1,4,1,4, 1,4,1,4,1,4,1,4, 1,4,1,4,1,4,1,4, 1,4,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteV_f_oddGreaterEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {3,1,3,2,3,1,3,2, 3,1,3,2,3,1,3,2, 3,1,3,2,3,1,3,2, 3,1,3,2,3,1,3,2, 3,2,1,2};
+  float src2[size+2] = {4,1,4,1,4,1,4,1, 4,1,4,1,4,1,4,1, 4,1,4,1,4,1,4,1, 4,1,4,1,4,1,4,1, 4,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpGteV_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src1[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                               -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                            -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                      0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                     };
+  float src2[size] = {0.0};
+
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x000076ec};
+  unsigned int refDstMaskOdd[] ={0x000376e};  
+  int resMaskCount = 1;
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\r\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpGteV_f/main.cpp
+++ b/test/nmpu0/cmpGteV_f/main.cpp
@@ -16,6 +16,7 @@ int cmpGteV_f_size69_resultCorrect();
 int cmpGteV_f_evenGreaterEqual_maskCorrect();
 int cmpGteV_f_oddGreaterEqual_maskCorrect();
 int cmpGteV_f_comparisonTest_maskCorrect();
+int cmpGteV_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpGteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpGteV_f_evenGreaterEqual_maskCorrect);
 	  RUN_TEST(cmpGteV_f_oddGreaterEqual_maskCorrect);
 	  RUN_TEST(cmpGteV_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpGteV_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -347,6 +349,74 @@ int cmpGteV_f_comparisonTest_maskCorrect(){
     printf("dstMaskEven = %0x\r\n", dstMaskEven[i]);
     printf("refDstMaskOdd = %0x\r\n", refDstMaskOdd[i]);
     printf("dstMaskOdd = %0x\r\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpGteV_f_size69_dstMaskExtraWordsNotChanged (){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  constexpr int size = 69;
+  float src1[srcSize] = {0};
+  float src2[srcSize] = {0};
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src1[i] = 1.0;
+    src2[i] = 0.0;
+  }
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpGteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
   }
 #endif //DEBUG
 

--- a/test/nmpu0/cmpLtC_f/main.cpp
+++ b/test/nmpu0/cmpLtC_f/main.cpp
@@ -16,6 +16,7 @@ int cmpLtC_f_size69_resultCorrect();
 int cmpLtC_f_oddLess_maskCorrect();
 int cmpLtC_f_evenLess_maskCorrect();
 int cmpLtC_f_comparisonTest_maskCorrect();
+int cmpLtC_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpLtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpLtC_f_oddLess_maskCorrect);
 	  RUN_TEST(cmpLtC_f_evenLess_maskCorrect);
 	  RUN_TEST(cmpLtC_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpLtC_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -329,5 +331,71 @@ int cmpLtC_f_comparisonTest_maskCorrect(){
   TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
   TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
 
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpLtC_f_size69_dstMaskExtraWordsNotChanged(){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  float src[srcSize] = {0};
+  constexpr int size = 69;
+  float C = 2.0;
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
   return 0;
 }

--- a/test/nmpu0/cmpLtC_f/main.cpp
+++ b/test/nmpu0/cmpLtC_f/main.cpp
@@ -1,0 +1,333 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpLtC_f_size0_resultCorrect();
+int cmpLtC_f_size1_resultCorrect();
+int cmpLtC_f_size63_resultCorrect();
+int cmpLtC_f_size64_resultCorrect();
+int cmpLtC_f_size68_resultCorrect();
+int cmpLtC_f_size69_resultCorrect();
+int cmpLtC_f_oddLess_maskCorrect();
+int cmpLtC_f_evenLess_maskCorrect();
+int cmpLtC_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpLtC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpLtC_f_size0_resultCorrect);
+	  RUN_TEST(cmpLtC_f_size1_resultCorrect);
+	  RUN_TEST(cmpLtC_f_size63_resultCorrect);
+	  RUN_TEST(cmpLtC_f_size64_resultCorrect);
+	  RUN_TEST(cmpLtC_f_size68_resultCorrect);
+	  RUN_TEST(cmpLtC_f_size69_resultCorrect);
+	  RUN_TEST(cmpLtC_f_oddLess_maskCorrect);
+	  RUN_TEST(cmpLtC_f_evenLess_maskCorrect);
+	  RUN_TEST(cmpLtC_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpLtC_f_size0_resultCorrect(){
+
+  float src[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtC_f_size1_resultCorrect(){
+
+  float src[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLtC_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLtC_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLtC_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+  src[4] = 0.0;
+  src[7] = 0.0;
+  src[64] = 0.0;
+  src[67] = 0.0;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtC_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src[size] = {0};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+  src[4] = 0.0;
+  src[7] = 0.0;
+  src[64] = 0.0;
+  src[67] = 0.0;
+  src[68] = 0.0;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtC_f_oddLess_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {1,0,2,0,1,0,2,0, 1,0,2,0,1,0,2,0, 1,0,2,0,1,0,2,0, 1,0,2,0,1,0,2,0, 1,0,2,1};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtC_f_evenLess_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0,1,0,2,0,1,0,2, 0,1,0,2,0,1,0,2, 0,1,0,2,0,1,0,2, 0,1,0,2,0,1,0,2, 0,1,2,1};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtC_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                              -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                           -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                    };
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00008913};
+  unsigned int refDstMaskOdd[] ={0x000c891};  
+  int resMaskCount = 1;
+
+  cmpLtC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpLtV_f/main.cpp
+++ b/test/nmpu0/cmpLtV_f/main.cpp
@@ -1,0 +1,355 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpLtV_f_size0_resultCorrect();
+int cmpLtV_f_size1_resultCorrect();
+int cmpLtV_f_size63_resultCorrect();
+int cmpLtV_f_size64_resultCorrect();
+int cmpLtV_f_size68_resultCorrect();
+int cmpLtV_f_size69_resultCorrect();
+int cmpLtV_f_oddLess_maskCorrect();
+int cmpLtV_f_evenLess_maskCorrect();
+int cmpLtV_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpLtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpLtV_f_size0_resultCorrect);
+	  RUN_TEST(cmpLtV_f_size1_resultCorrect);
+	  RUN_TEST(cmpLtV_f_size63_resultCorrect);
+	  RUN_TEST(cmpLtV_f_size64_resultCorrect);
+	  RUN_TEST(cmpLtV_f_size68_resultCorrect);
+	  RUN_TEST(cmpLtV_f_size69_resultCorrect);
+	  RUN_TEST(cmpLtV_f_oddLess_maskCorrect);
+	  RUN_TEST(cmpLtV_f_evenLess_maskCorrect);
+	  RUN_TEST(cmpLtV_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpLtV_f_size0_resultCorrect(){
+
+  float src1[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float src2[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtV_f_size1_resultCorrect(){
+
+  float src1[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float src2[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLtV_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLtV_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLtV_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  src1[4] = 0.0;
+  src1[7] = 0.0;
+  src1[64] = 0.0;
+  src1[67] = 0.0;
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtV_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 1.0;
+  }
+
+  src1[4] = 0.0;
+  src1[7] = 0.0;
+  src1[64] = 0.0;
+  src1[67] = 0.0;
+  src1[68] = 0.0;
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtV_f_oddLess_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {1,0,2,0,1,0,2,0, 1,0,2,0,1,0,2,0, 1,0,2,0,1,0,2,0, 1,0,2,0,1,0,2,0, 1,0,2,1};
+  float src2[size+2] = {1,3,2,3,1,3,2,3, 1,3,2,3,1,3,2,3, 1,3,2,3,1,3,2,3, 1,3,2,3,1,3,2,3, 1,3,2,1};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtV_f_evenLess_maskCorrect(){
+  constexpr int size = 34;
+  float src1[size+2] = {0,1,0,2,0,1,0,2, 0,1,0,2,0,1,0,2, 0,1,0,2,0,1,0,2, 0,1,0,2,0,1,0,2, 0,1,2,1};
+  float src2[size+2] = {3,1,3,2,3,1,3,2, 3,1,3,2,3,1,3,2, 3,1,3,2,3,1,3,2, 3,1,3,2,3,1,3,2, 3,1,2,1};
+  unsigned int dstMaskEven[] ={0xffffffff};  
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLtV_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src1[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                               -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                            -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                      0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                     };
+  float src2[size] ={0};
+
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00008913};
+  unsigned int refDstMaskOdd[] ={0x000c891};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpLtV_f/main.cpp
+++ b/test/nmpu0/cmpLtV_f/main.cpp
@@ -16,6 +16,7 @@ int cmpLtV_f_size69_resultCorrect();
 int cmpLtV_f_oddLess_maskCorrect();
 int cmpLtV_f_evenLess_maskCorrect();
 int cmpLtV_f_comparisonTest_maskCorrect();
+int cmpLtV_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpLtV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpLtV_f_oddLess_maskCorrect);
 	  RUN_TEST(cmpLtV_f_evenLess_maskCorrect);
 	  RUN_TEST(cmpLtV_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpLtV_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -335,6 +337,73 @@ int cmpLtV_f_comparisonTest_maskCorrect(){
   for (int i=0; i<size; i++) {
     src2[i] = 0.0;
   }
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+//Check that function does not change dstMasks more than it is needed
+int cmpLtV_f_size69_dstMaskExtraWordsNotChanged (){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  constexpr int size = 69;
+  float src1[srcSize] = {0};
+  float src2[srcSize] = {0};
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src1[i] = 1.0;
+    src2[i] = 2.0;
+  }
+
+  cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
 
   cmpLtV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
 

--- a/test/nmpu0/cmpLteC_f/main.cpp
+++ b/test/nmpu0/cmpLteC_f/main.cpp
@@ -1,0 +1,339 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpLteC_f_size0_resultCorrect();
+int cmpLteC_f_size1_resultCorrect();
+int cmpLteC_f_size63_resultCorrect();
+int cmpLteC_f_size64_resultCorrect();
+int cmpLteC_f_size68_resultCorrect();
+int cmpLteC_f_size69_resultCorrect();
+int cmpLteC_f_evenLessEqual_maskCorrect();
+int cmpLteC_f_oddLessEqual_maskCorrect();
+int cmpLteC_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpLteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpLteC_f_size0_resultCorrect);
+	  RUN_TEST(cmpLteC_f_size1_resultCorrect);
+	  RUN_TEST(cmpLteC_f_size63_resultCorrect);
+	  RUN_TEST(cmpLteC_f_size64_resultCorrect);
+	  RUN_TEST(cmpLteC_f_size68_resultCorrect);
+	  RUN_TEST(cmpLteC_f_size69_resultCorrect);
+	  RUN_TEST(cmpLteC_f_evenLessEqual_maskCorrect);
+	  RUN_TEST(cmpLteC_f_oddLessEqual_maskCorrect);
+	  RUN_TEST(cmpLteC_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpLteC_f_size0_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteC_f_size1_resultCorrect(){
+
+  float src[] = {2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLteC_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src[size] = {0};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src[i] = 2.0;
+  }
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLteC_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src[size] = {0};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src[i] = 2.0;
+  }
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLteC_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src[size] = {0};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 3.0;
+  }
+  src[4] = 1.0;
+  src[7] = 2.0;
+  src[64] = 2.0;
+  src[67] = 1.0;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteC_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src[size] = {0};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 3.0;
+  }
+  src[4] = 1.0;
+  src[7] = 2.0;
+  src[64] = 2.0;
+  src[67] = 1.0;
+  src[68] = 1.0;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteC_f_evenLessEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {2,3,1,3,2,3,1,3, 2,3,1,3,2,3,1,3, 2,3,1,3,2,3,1,3, 2,3,1,3,2,3,1,3, 2,3,1,2};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteC_f_oddLessEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {3,2,3,1,3,2,3,1, 3,2,3,1,3,2,3,1, 3,2,3,1,3,2,3,1, 3,2,3,1,3,2,3,1, 3,2,1,2};
+  float C = 2.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteC_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                              -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                           -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                    };
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0000d9b3};
+  unsigned int refDstMaskOdd[] ={0x000cd9b};  
+  int resMaskCount = 1;
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpLteC_f/main.cpp
+++ b/test/nmpu0/cmpLteC_f/main.cpp
@@ -16,6 +16,7 @@ int cmpLteC_f_size69_resultCorrect();
 int cmpLteC_f_evenLessEqual_maskCorrect();
 int cmpLteC_f_oddLessEqual_maskCorrect();
 int cmpLteC_f_comparisonTest_maskCorrect();
+int cmpLteC_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpLteC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpLteC_f_evenLessEqual_maskCorrect);
 	  RUN_TEST(cmpLteC_f_oddLessEqual_maskCorrect);
 	  RUN_TEST(cmpLteC_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpLteC_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -335,5 +337,71 @@ int cmpLteC_f_comparisonTest_maskCorrect(){
   TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
   TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
 
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpLteC_f_size69_dstMaskExtraWordsNotChanged(){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  float src[srcSize] = {0};
+  constexpr int size = 69;
+  float C = 2.0;
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpLteC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
   return 0;
 }

--- a/test/nmpu0/cmpLteV_f/main.cpp
+++ b/test/nmpu0/cmpLteV_f/main.cpp
@@ -16,6 +16,7 @@ int cmpLteV_f_size69_resultCorrect();
 int cmpLteV_f_evenLessEqual_maskCorrect();
 int cmpLteV_f_oddLessEqual_maskCorrect();
 int cmpLteV_f_comparisonTest_maskCorrect();
+int cmpLteV_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpLteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpLteV_f_evenLessEqual_maskCorrect);
 	  RUN_TEST(cmpLteV_f_oddLessEqual_maskCorrect);
 	  RUN_TEST(cmpLteV_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpLteV_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -337,6 +339,74 @@ int cmpLteV_f_comparisonTest_maskCorrect(){
   unsigned int refDstMaskEven[] = {0x0000d9b3};
   unsigned int refDstMaskOdd[] ={0x000cd9b};  
   int resMaskCount = 1;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpLteV_f_size69_dstMaskExtraWordsNotChanged (){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  constexpr int size = 69;
+  float src1[srcSize] = {0};
+  float src2[srcSize] = {0};
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src1[i] = 1.0;
+    src2[i] = 2.0;
+  }
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
 
   cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
 

--- a/test/nmpu0/cmpLteV_f/main.cpp
+++ b/test/nmpu0/cmpLteV_f/main.cpp
@@ -1,0 +1,357 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpLteV_f_size0_resultCorrect();
+int cmpLteV_f_size1_resultCorrect();
+int cmpLteV_f_size63_resultCorrect();
+int cmpLteV_f_size64_resultCorrect();
+int cmpLteV_f_size68_resultCorrect();
+int cmpLteV_f_size69_resultCorrect();
+int cmpLteV_f_evenLessEqual_maskCorrect();
+int cmpLteV_f_oddLessEqual_maskCorrect();
+int cmpLteV_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpLteV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpLteV_f_size0_resultCorrect);
+	  RUN_TEST(cmpLteV_f_size1_resultCorrect);
+	  RUN_TEST(cmpLteV_f_size63_resultCorrect);
+	  RUN_TEST(cmpLteV_f_size64_resultCorrect);
+	  RUN_TEST(cmpLteV_f_size68_resultCorrect);
+	  RUN_TEST(cmpLteV_f_size69_resultCorrect);
+	  RUN_TEST(cmpLteV_f_evenLessEqual_maskCorrect);
+	  RUN_TEST(cmpLteV_f_oddLessEqual_maskCorrect);
+	  RUN_TEST(cmpLteV_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpLteV_f_size0_resultCorrect(){
+
+  float src1[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float src2[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteV_f_size1_resultCorrect(){
+
+  float src1[] = {2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1,2,1,2,1, 2,1,2,1};
+  float src2[] = {2,2,2,2,2,2,2,2, 2,2,2,2,2,2,2,2, 2,2,2,2,2,2,2,2, 2,2,2,2,2,2,2,2, 2,2,2,2};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLteV_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src1[i] = 2.0;
+  }
+
+  for (int i=0; i<size; i=i+1) {
+    src2[i] = 2.0;
+  }
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLteV_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i=i+2) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=1; i<size; i=i+2) {
+    src1[i] = 2.0;
+  }
+
+  for (int i=0; i<size; i=i+1) {
+    src2[i] = 2.0;
+  }
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpLteV_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 3.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 2.0;
+  }
+
+  src1[4] = 1.0;
+  src1[7] = 2.0;
+  src1[64] = 2.0;
+  src1[67] = 1.0;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteV_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 3.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 2.0;
+  src1[64] = 2.0;
+  src1[67] = 1.0;
+  src1[68] = 1.0;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 2.0;
+  }
+  
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteV_f_evenLessEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {2,1,3,1,2,1,3,1, 2,1,3,1,2,1,3,1, 2,1,3,1,2,1,3,1, 2,1,3,1,2,1,3,1, 2,1,3,2};
+  float src2[size+2] = {2,0,4,0,2,0,4,0, 2,0,4,0,2,0,4,0, 2,0,4,0,2,0,4,0, 2,0,4,0,2,0,4,0, 2,0,4,2};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteV_f_oddLessEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {1,3,1,2,1,3,1,2, 1,3,1,2,1,3,1,2, 1,3,1,2,1,3,1,2, 1,3,1,2,1,3,1,2, 1,3,2,2};
+  float src2[size+2] = {0,4,0,2,0,4,0,2, 0,4,0,2,0,4,0,2, 0,4,0,2,0,4,0,2, 0,4,0,2,0,4,0,2, 0,4,2,2};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpLteV_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src1[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                               -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                            -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                      0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                     };
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0000d9b3};
+  unsigned int refDstMaskOdd[] ={0x000cd9b};  
+  int resMaskCount = 1;
+
+  cmpLteV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpNeC_f/main.cpp
+++ b/test/nmpu0/cmpNeC_f/main.cpp
@@ -1,0 +1,335 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpNeC_f_size0_resultCorrect();
+int cmpNeC_f_size1_resultCorrect();
+int cmpNeC_f_size63_resultCorrect();
+int cmpNeC_f_size64_resultCorrect();
+int cmpNeC_f_size68_resultCorrect();
+int cmpNeC_f_size69_resultCorrect();
+int cmpNeC_f_evenNotEqual_maskCorrect();
+int cmpNeC_f_oddNotEqual_maskCorrect();
+int cmpNeC_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpNeC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpNeC_f_size0_resultCorrect);
+	  RUN_TEST(cmpNeC_f_size1_resultCorrect);
+	  RUN_TEST(cmpNeC_f_size63_resultCorrect);
+	  RUN_TEST(cmpNeC_f_size64_resultCorrect);
+	  RUN_TEST(cmpNeC_f_size68_resultCorrect);
+	  RUN_TEST(cmpNeC_f_size69_resultCorrect);
+	  RUN_TEST(cmpNeC_f_evenNotEqual_maskCorrect);
+	  RUN_TEST(cmpNeC_f_oddNotEqual_maskCorrect);
+	  RUN_TEST(cmpNeC_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpNeC_f_size0_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 1.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeC_f_size1_resultCorrect(){
+
+  float src[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpNeC_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpNeC_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpNeC_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+
+  src[4] = 1.0;
+  src[7] = 1.0;
+  src[64] = 1.0;
+  src[67] = 1.0;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeC_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src[size] = {0};
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src[i] = 0.0;
+  }
+
+  src[4] = 1.0;
+  src[7] = 1.0;
+  src[64] = 1.0;
+  src[67] = 1.0;
+  src[68] = 1.0;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeC_f_evenNotEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,1,0.5,0,0.5,1,0.5, 0,0.5,0,0};
+  float C = 0.5;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeC_f_oddNotEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src[size+2] = {0.5,1,0.5,0,0.5,1,0.5,0, 0.5,1,0.5,0,0.5,1,0.5,0, 0.5,1,0.5,0,0.5,1,0.5,0, 0.5,1,0.5,0,0.5,1,0.5,0, 0.5,0,0,0};
+  float C = 0.5;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeC_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                              -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                           -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                    };
+  float C = 0.0;
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0000af5f};
+  unsigned int refDstMaskOdd[] ={0x0000faf5};  
+  int resMaskCount = 1;
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cmpNeC_f/main.cpp
+++ b/test/nmpu0/cmpNeC_f/main.cpp
@@ -16,6 +16,7 @@ int cmpNeC_f_size69_resultCorrect();
 int cmpNeC_f_evenNotEqual_maskCorrect();
 int cmpNeC_f_oddNotEqual_maskCorrect();
 int cmpNeC_f_comparisonTest_maskCorrect();
+int cmpNeC_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpNeC_f(float* src, float C, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpNeC_f_evenNotEqual_maskCorrect);
 	  RUN_TEST(cmpNeC_f_oddNotEqual_maskCorrect);
 	  RUN_TEST(cmpNeC_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpNeC_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -331,5 +333,71 @@ int cmpNeC_f_comparisonTest_maskCorrect(){
   TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
   TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
 
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpNeC_f_size69_dstMaskExtraWordsNotChanged(){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  float src[srcSize] = {0};
+  constexpr int size = 69;
+  float C = 0.0;
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src[i] = 1.0;
+  }
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
+
+  cmpNeC_f(src, C, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
   return 0;
 }

--- a/test/nmpu0/cmpNeV_f/main.cpp
+++ b/test/nmpu0/cmpNeV_f/main.cpp
@@ -16,6 +16,7 @@ int cmpNeV_f_size69_resultCorrect();
 int cmpNeV_f_evenNotEqual_maskCorrect();
 int cmpNeV_f_oddNotEqual_maskCorrect();
 int cmpNeV_f_comparisonTest_maskCorrect();
+int cmpNeV_f_size69_dstMaskExtraWordsNotChanged();
 
 extern "C" void cmpNeV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
 
@@ -31,6 +32,7 @@ int main()
 	  RUN_TEST(cmpNeV_f_evenNotEqual_maskCorrect);
 	  RUN_TEST(cmpNeV_f_oddNotEqual_maskCorrect);
 	  RUN_TEST(cmpNeV_f_comparisonTest_maskCorrect);
+	  RUN_TEST(cmpNeV_f_size69_dstMaskExtraWordsNotChanged);
 
 	return 0;
 }
@@ -329,6 +331,74 @@ int cmpNeV_f_comparisonTest_maskCorrect(){
   unsigned int refDstMaskEven[] = {0x0000af5f};
   unsigned int refDstMaskOdd[] ={0x0000faf5};  
   int resMaskCount = 1;
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+//Check that function does not change dstMasks more than it is needed
+int cmpNeV_f_size69_dstMaskExtraWordsNotChanged (){
+
+  constexpr int resMaskCount = 4;
+  constexpr int srcSize = resMaskCount*32*2;//32 - size of one mask, 2 - two masks: even and odd 
+  constexpr int size = 69;
+  float src1[srcSize] = {0};
+  float src2[srcSize] = {0};
+  unsigned int dstMaskEven[resMaskCount]    = {0xffffffff, 0xffffffff, 0xAAAAAAAA, 0x55555555};
+  unsigned int dstMaskOdd[resMaskCount]     = {0xffffffff, 0xffffffff, 0x55555555, 0xAAAAAAAA};  
+  unsigned int refDstMaskEven[resMaskCount] = {0xffffffff,        0x7, 0xAAAAAAAA, 0x55555555};
+  unsigned int refDstMaskOdd[resMaskCount]  = {0xffffffff,        0x3, 0x55555555, 0xAAAAAAAA};  
+
+  //Set all alements of src1 and src2 so that comparison result will be true
+  for (int i=0; i<srcSize; i++) {
+    src1[i] = 1.0;
+    src2[i] = 0.0;
+  }
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  //Swap dstMask elements 2 and 3 and test one more time
+  unsigned int tmp = 0;
+
+  tmp = dstMaskEven[2];
+  dstMaskEven[2] = dstMaskEven[3];
+  dstMaskEven[3] = tmp;
+  refDstMaskEven[2] = dstMaskEven[2];
+  refDstMaskEven[3] = dstMaskEven[3];
+
+  tmp = dstMaskOdd[2];
+  dstMaskOdd[2] = dstMaskOdd[3];
+  dstMaskOdd[3] = tmp;
+  refDstMaskOdd[2] = dstMaskOdd[2];
+  refDstMaskOdd[3] = dstMaskOdd[3];
 
   cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
 

--- a/test/nmpu0/cmpNeV_f/main.cpp
+++ b/test/nmpu0/cmpNeV_f/main.cpp
@@ -1,0 +1,349 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+#include <float.h>
+#include <math.h>
+
+//#define DEBUG
+int cmpNeV_f_size0_resultCorrect();
+int cmpNeV_f_size1_resultCorrect();
+int cmpNeV_f_size63_resultCorrect();
+int cmpNeV_f_size64_resultCorrect();
+int cmpNeV_f_size68_resultCorrect();
+int cmpNeV_f_size69_resultCorrect();
+int cmpNeV_f_evenNotEqual_maskCorrect();
+int cmpNeV_f_oddNotEqual_maskCorrect();
+int cmpNeV_f_comparisonTest_maskCorrect();
+
+extern "C" void cmpNeV_f(float* src1, float* src2, nm1* dstMaskEven, nm1* dstMaskOdd, int size);
+
+int main()
+{
+
+	  RUN_TEST(cmpNeV_f_size0_resultCorrect);
+	  RUN_TEST(cmpNeV_f_size1_resultCorrect);
+	  RUN_TEST(cmpNeV_f_size63_resultCorrect);
+	  RUN_TEST(cmpNeV_f_size64_resultCorrect);
+	  RUN_TEST(cmpNeV_f_size68_resultCorrect);
+	  RUN_TEST(cmpNeV_f_size69_resultCorrect);
+	  RUN_TEST(cmpNeV_f_evenNotEqual_maskCorrect);
+	  RUN_TEST(cmpNeV_f_oddNotEqual_maskCorrect);
+	  RUN_TEST(cmpNeV_f_comparisonTest_maskCorrect);
+
+	return 0;
+}
+
+int cmpNeV_f_size0_resultCorrect(){
+
+  float src1[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  float src2[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xffffffff};
+  unsigned int refDstMaskOdd[] ={0xffffffff};  
+  int size = 0;
+  int resMaskCount = 1;
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeV_f_size1_resultCorrect(){
+
+  float src1[] = {1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1};
+  float src2[] = {0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 0,0,0,0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x1};
+  unsigned int refDstMaskOdd[] ={0x0};  
+  int size = 1;
+  int resMaskCount = 1;
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpNeV_f_size63_resultCorrect(){
+
+  constexpr int size = 63;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0x7FFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpNeV_f_size64_resultCorrect(){
+
+  constexpr int size = 64;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0x00000000};
+  unsigned int dstMaskOdd[] ={0x00000000};  
+  unsigned int refDstMaskEven[] = {0xFFFFFFFF};
+  unsigned int refDstMaskOdd[] ={0xFFFFFFFF};  
+  int resMaskCount = 1;
+
+  for (int i=0; i<size; i++) {
+    src1[i] = 1.0;
+  }
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+int cmpNeV_f_size68_resultCorrect(){
+
+  constexpr int size = 68;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x1};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 1.0;
+  src1[64] = 1.0;
+  src1[67] = 1.0;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeV_f_size69_resultCorrect(){
+
+  constexpr int size = 69;
+  float src1[size] = {0};
+  float src2[size] = {0};
+  unsigned int dstMaskEven[] = {0xffffffff, 0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff, 0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x4,0x5};
+  unsigned int refDstMaskOdd[] ={0x8,0x2};  
+  int resMaskCount = 2;
+
+  //Setup src values which correspond to reference dst masks
+  for (int i=0; i<size; i++) {
+    src1[i] = 0.0;
+  }
+  src1[4] = 1.0;
+  src1[7] = 1.0;
+  src1[64] = 1.0;
+  src1[67] = 1.0;
+  src1[68] = 1.0;
+
+  for (int i=0; i<size; i++) {
+    src2[i] = 0.0;
+  }
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeV_f_evenNotEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5};
+  float src2[size+2] = {  0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  1,0.5,  0,0.5,  1,0.5,   0,0.5,  0,  0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0001FFFF};
+  unsigned int refDstMaskOdd[] ={0x00000000};  
+  int resMaskCount = 1;
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeV_f_oddNotEqual_maskCorrect(){
+
+  constexpr int size = 34;
+  float src1[size+2] = {0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5, 0.5,0.5,0.5,0.5,};
+  float src2[size+2] = {0.5,  1,0.5,  0,0.5,  1,0.5,  0, 0.5,  1,0.5,  0,0.5,  1,0.5,  0, 0.5,  1,0.5,  0,0.5,  1,0.5,  0, 0.5,  1,0.5,  0,0.5,  1,0.5,  0, 0.5,  0,  0,  0,};
+  unsigned int dstMaskEven[] ={0xffffffff};  
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x00000000};
+  unsigned int refDstMaskOdd[] ={0x0001FFFF};  
+  int resMaskCount = 1;
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}
+
+
+int cmpNeV_f_comparisonTest_maskCorrect(){
+
+  constexpr int size = 32;
+  float src1[size] = {-FLT_MAX,-FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,
+                               -FLT_MIN,    -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,
+                                            -1.0,     0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,
+                                                      0.0,     1.0, FLT_MIN, FLT_MAX,     0.0,-FLT_MAX,-FLT_MIN,    -1.0
+                     };
+  float src2[size] = {0.0};
+  unsigned int dstMaskEven[] = {0xffffffff};
+  unsigned int dstMaskOdd[] ={0xffffffff};  
+  unsigned int refDstMaskEven[] = {0x0000af5f};
+  unsigned int refDstMaskOdd[] ={0x0000faf5};  
+  int resMaskCount = 1;
+
+  cmpNeV_f(src1, src2, (nm1*)dstMaskEven, (nm1*)dstMaskOdd, size);
+
+#ifdef DEBUG
+  for (int i=0; i<resMaskCount; i++) {
+    printf("\r\n");
+    printf("refDstMaskEven = %0x\n", refDstMaskEven[i]);
+    printf("dstMaskEven = %0x\n", dstMaskEven[i]);
+    printf("refDstMaskOdd = %0x\n", refDstMaskOdd[i]);
+    printf("dstMaskOdd = %0x\n", dstMaskOdd[i]);
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dstMaskEven, refDstMaskEven, resMaskCount);
+  TEST_ARRAYS_EQUALI(dstMaskOdd, refDstMaskOdd, resMaskCount);
+
+  return 0;
+}

--- a/test/nmpu0/cnvDividedMaskToIndices/main.cpp
+++ b/test/nmpu0/cnvDividedMaskToIndices/main.cpp
@@ -14,6 +14,7 @@ int cnvDividedMaskToIndices_size0_resultCorrect();
 int cnvDividedMaskToIndices_size2_resultCorrect();
 int cnvDividedMaskToIndices_size64_resultCorrect();
 int cnvDividedMaskToIndices_size66_resultCorrect();
+int cnvDividedMaskToIndices_size66_dstVecExtraElementsNotChanged();
 
 extern "C" int cnvDividedMaskToIndices(nm1* maskEven, nm1* maskOdd, int* offsets, int size);
 nm32s arrayToInt (unsigned int* array, int count);
@@ -28,6 +29,7 @@ int main()
   RUN_TEST(cnvDividedMaskToIndices_size2_resultCorrect);
   RUN_TEST(cnvDividedMaskToIndices_size64_resultCorrect);
   RUN_TEST(cnvDividedMaskToIndices_size66_resultCorrect);
+  RUN_TEST(cnvDividedMaskToIndices_size66_dstVecExtraElementsNotChanged);
 	return 0;
 }
 
@@ -115,7 +117,7 @@ int cnvDividedMaskToIndices_allZeroes_returns0(){
 #endif //DEBUG
 
   TEST_ASSERT(result == refResult);
-  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE*2);//Also check that dstVec is not changed
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, size);//Also check that dstVec is not changed
 
   return 0;
 }
@@ -326,6 +328,87 @@ int cnvDividedMaskToIndices_size66_resultCorrect(){
   int refDstVec[maxResult] = {62, 63, 64, 65};
 
   int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}
+
+
+
+int cnvDividedMaskToIndices_size66_dstVecExtraElementsNotChanged(){
+
+  constexpr int maxResult = 128;
+  unsigned int testMaskEven[] = {0x80000000, 0xffffffff}; 
+  unsigned int testMaskOdd[] =  {0x80000000, 0xffffffff}; 
+  int dstVec[maxResult] = {0};
+  int size = 66;
+  int refResult = 4; 
+  int refDstVec[maxResult] = {62, 63, 64, 65};
+
+  dstVec[4] = refDstVec[4] = 777;
+  dstVec[5] = refDstVec[5] = 888;
+
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  //swap extra elements and test one more time
+
+  unsigned int tmp = 0;
+  tmp = refDstVec[4];
+  dstVec[4] = refDstVec[4] = refDstVec[6];
+  dstVec[5] = refDstVec[5] = tmp;
+
+  result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
 
 #ifdef DEBUG
 

--- a/test/nmpu0/cnvDividedMaskToIndices/main.cpp
+++ b/test/nmpu0/cnvDividedMaskToIndices/main.cpp
@@ -1,0 +1,357 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define TEST_MASK_SIZE 17
+
+int cnvDividedMaskToIndices_allOnes_returns34();
+int cnvDividedMaskToIndices_allZeroes_returns0();
+int cnvDividedMaskToIndices_randomOnes_returns18();
+int cnvDividedMaskToIndices_longDistanceBetweenOnes_returns2();
+int cnvDividedMaskToIndices_size0_resultCorrect();
+int cnvDividedMaskToIndices_size2_resultCorrect();
+int cnvDividedMaskToIndices_size64_resultCorrect();
+int cnvDividedMaskToIndices_size66_resultCorrect();
+
+extern "C" int cnvDividedMaskToIndices(nm1* maskEven, nm1* maskOdd, int* offsets, int size);
+nm32s arrayToInt (unsigned int* array, int count);
+
+int main()
+{
+  RUN_TEST(cnvDividedMaskToIndices_allOnes_returns34);
+  RUN_TEST(cnvDividedMaskToIndices_allZeroes_returns0);
+  RUN_TEST(cnvDividedMaskToIndices_randomOnes_returns18);
+  RUN_TEST(cnvDividedMaskToIndices_longDistanceBetweenOnes_returns2);
+  RUN_TEST(cnvDividedMaskToIndices_size0_resultCorrect);
+  RUN_TEST(cnvDividedMaskToIndices_size2_resultCorrect);
+  RUN_TEST(cnvDividedMaskToIndices_size64_resultCorrect);
+  RUN_TEST(cnvDividedMaskToIndices_size66_resultCorrect);
+	return 0;
+}
+
+nm32s arrayToInt (unsigned int* array, int count) 
+{
+  nm32s res = 0;
+  for (int i=0; i<count; i++)
+  {
+    res = res | (array[i] << i);
+  }
+  return res;
+}
+
+int cnvDividedMaskToIndices_allOnes_returns34(){
+
+  unsigned int testMaskEvenArray[TEST_MASK_SIZE] = {1,  1,  1,  1,   1,  1,  1,  1,     1,  1,  1,  1,     1,  1,  1,  1,    1};
+  unsigned int testMaskOddArray[TEST_MASK_SIZE]  =   {1,  1,  1,  1,   1,  1,  1,  1,     1,  1,  1,  1,     1,  1,  1,  1,    1};
+  constexpr int size = TEST_MASK_SIZE*2;
+  int dstVec[size] = {0};
+  int refResult = 34; 
+  int refDstVec[size] ={0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33};
+
+  nm32s testMaskEven = arrayToInt (testMaskEvenArray, TEST_MASK_SIZE);
+  nm32s testMaskOdd = arrayToInt (testMaskOddArray, TEST_MASK_SIZE);
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvDividedMaskToIndices_allZeroes_returns0(){
+
+  unsigned int testMaskEvenArray[TEST_MASK_SIZE] = {0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0};
+  unsigned int testMaskOddArray[TEST_MASK_SIZE]  = {0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0};
+  constexpr int size = TEST_MASK_SIZE*2;
+  int dstVec[size];
+  int refResult = 0; 
+  int refDstVec[size];
+
+  for (int i = 0; i < size; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+
+  nm32s testMaskEven = arrayToInt (testMaskEvenArray, TEST_MASK_SIZE);
+  nm32s testMaskOdd = arrayToInt (testMaskOddArray, TEST_MASK_SIZE);
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE*2);//Also check that dstVec is not changed
+
+  return 0;
+}
+
+
+int cnvDividedMaskToIndices_randomOnes_returns18(){
+
+  unsigned int testMaskEvenArray[TEST_MASK_SIZE] = {0,  0,  1,  1,   0,  1,  0,  1,   0,  1,  0,  1,   1,  1,  0,  1,   0};
+  unsigned int testMaskOddArray[TEST_MASK_SIZE]  =   {0,  0,  1,  1,   0,  1,  0,  1,   0,  1,  0,  1,   1,  1,  0,  1,   0};
+  constexpr int size = TEST_MASK_SIZE*2;
+  int dstVec[size];
+  int refResult = 18; 
+  int refDstVec[size] ={4,5,6,7,10,11,14,15,18,19,22,23,24,25,26,27,30,31};
+
+  nm32s testMaskEven = arrayToInt (testMaskEvenArray, TEST_MASK_SIZE);
+  nm32s testMaskOdd = arrayToInt (testMaskOddArray, TEST_MASK_SIZE);
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvDividedMaskToIndices_longDistanceBetweenOnes_returns2(){
+
+  unsigned int testMaskEven[2] = {0x00000002, 0x00000000}; 
+  unsigned int testMaskOdd[2] =  {0x00000000, 0x80000000}; 
+  constexpr int size = 128;
+  int dstVec[size];
+  int refResult = 2; 
+  int refDstVec[size] ={2, 127};
+
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+
+int cnvDividedMaskToIndices_size0_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  unsigned int testMaskEven = 0xffffffff; 
+  unsigned int testMaskOdd =  0xffffffff; 
+  int dstVec[maxResult];
+  int size = 0;
+  int refResult = 0; 
+  int refDstVec[maxResult];
+
+  for (int i = 0; i < maxResult; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//check that dstVec is not changed
+
+  return 0;
+}
+
+int cnvDividedMaskToIndices_size2_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  unsigned int testMaskEven = 0xffffffff; 
+  unsigned int testMaskOdd =  0xffffffff; 
+  int dstVec[maxResult] = {0};
+  int size = 2;
+  int refResult = 2; 
+  int refDstVec[maxResult] = {0,1};
+
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}
+
+int cnvDividedMaskToIndices_size64_resultCorrect(){
+
+  constexpr int maxResult = 128;
+  unsigned int testMaskEven[] = {0x80000000, 0xffffffff}; 
+  unsigned int testMaskOdd[] =  {0x80000000, 0xffffffff }; 
+  int dstVec[maxResult] = {0};
+  int size = 64;
+  int refResult = 2; 
+  int refDstVec[maxResult] = {62, 63};
+
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}
+
+
+int cnvDividedMaskToIndices_size66_resultCorrect(){
+
+  constexpr int maxResult = 128;
+  unsigned int testMaskEven[] = {0x80000000, 0xffffffff}; 
+  unsigned int testMaskOdd[] =  {0x80000000, 0xffffffff}; 
+  int dstVec[maxResult] = {0};
+  int size = 66;
+  int refResult = 4; 
+  int refDstVec[maxResult] = {62, 63, 64, 65};
+
+  int result = cnvDividedMaskToIndices((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}

--- a/test/nmpu0/cnvDividedMaskToOffsets/main.cpp
+++ b/test/nmpu0/cnvDividedMaskToOffsets/main.cpp
@@ -14,6 +14,7 @@ int cnvDividedMaskToOffsets_size0_resultCorrect();
 int cnvDividedMaskToOffsets_size2_resultCorrect();
 int cnvDividedMaskToOffsets_size64_resultCorrect();
 int cnvDividedMaskToOffsets_size66_resultCorrect();
+int cnvDividedMaskToOffsets_size66_dstVecExtraElementsNotChanged();
 
 extern "C" int cnvDividedMaskToOffsets(nm1* maskEven, nm1* maskOdd, int* offsets, int size);
 nm32s arrayToInt (unsigned int* array, int count);
@@ -29,6 +30,7 @@ int main()
   RUN_TEST(cnvDividedMaskToOffsets_size2_resultCorrect);
   RUN_TEST(cnvDividedMaskToOffsets_size64_resultCorrect);
   RUN_TEST(cnvDividedMaskToOffsets_size66_resultCorrect);
+  RUN_TEST(cnvDividedMaskToOffsets_size66_dstVecExtraElementsNotChanged);
 
 	return 0;
 }
@@ -119,7 +121,7 @@ int cnvDividedMaskToOffsets_allZeroes_returns0(){
 #endif //DEBUG
 
   TEST_ASSERT(result == refResult);
-  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE*2);//Also check that dstVec is not changed
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, size);//Also check that dstVec is not changed
 
   return 0;
 }
@@ -327,6 +329,83 @@ int cnvDividedMaskToOffsets_size66_resultCorrect(){
   int refDstVec[maxResult] = {62, 1, 1, 1};
 
   int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}
+
+int cnvDividedMaskToOffsets_size66_dstVecExtraElementsNotChanged(){
+
+  constexpr int maxResult = 128;
+  unsigned int testMaskEven[] = {0x80000000, 0xffffffff}; 
+  unsigned int testMaskOdd[] =  {0x80000000, 0xffffffff}; 
+  int dstVec[maxResult] = {0};
+  int size = 66;
+  int refResult = 4; 
+  int refDstVec[maxResult] = {62, 1, 1, 1};
+
+  dstVec[4] = refDstVec[4] = 777;
+  dstVec[5] = refDstVec[5] = 888;
+
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  //swap extra elements and test one more time
+
+  unsigned int tmp = 0;
+  tmp = refDstVec[4];
+  dstVec[4] = refDstVec[4] = refDstVec[6];
+  dstVec[5] = refDstVec[5] = tmp;
+
+  result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
 
 #ifdef DEBUG
   for (int i = 0; i < 2; i++){

--- a/test/nmpu0/cnvDividedMaskToOffsets/main.cpp
+++ b/test/nmpu0/cnvDividedMaskToOffsets/main.cpp
@@ -1,0 +1,357 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define		TEST_MASK_SIZE 		17	
+
+int cnvDividedMaskToOffsets_allOnes_returns34();
+int cnvDividedMaskToOffsets_allZeroes_returns0();
+int cnvDividedMaskToOffsets_randomOnes_returns18();
+int cnvDividedMaskToOffsets_longDistanceBetweenOnes_returns2();
+int cnvDividedMaskToOffsets_size0_resultCorrect();
+int cnvDividedMaskToOffsets_size2_resultCorrect();
+int cnvDividedMaskToOffsets_size64_resultCorrect();
+int cnvDividedMaskToOffsets_size66_resultCorrect();
+
+extern "C" int cnvDividedMaskToOffsets(nm1* maskEven, nm1* maskOdd, int* offsets, int size);
+nm32s arrayToInt (unsigned int* array, int count);
+
+int main()
+{
+
+  RUN_TEST(cnvDividedMaskToOffsets_allOnes_returns34);
+  RUN_TEST(cnvDividedMaskToOffsets_allZeroes_returns0);
+  RUN_TEST(cnvDividedMaskToOffsets_randomOnes_returns18);
+  RUN_TEST(cnvDividedMaskToOffsets_longDistanceBetweenOnes_returns2);
+  RUN_TEST(cnvDividedMaskToOffsets_size0_resultCorrect);
+  RUN_TEST(cnvDividedMaskToOffsets_size2_resultCorrect);
+  RUN_TEST(cnvDividedMaskToOffsets_size64_resultCorrect);
+  RUN_TEST(cnvDividedMaskToOffsets_size66_resultCorrect);
+
+	return 0;
+}
+
+nm32s arrayToInt (unsigned int* array, int count) 
+{
+  nm32s res = 0;
+  for (int i=0; i<count; i++)
+  {
+    res = res | (array[i] << i);
+  }
+  return res;
+}
+
+
+int cnvDividedMaskToOffsets_allOnes_returns34(){
+
+  unsigned int testMaskEvenArray[TEST_MASK_SIZE] = {1,  1,  1,  1,   1,  1,  1,  1,     1,  1,  1,  1,     1,  1,  1,  1,    1};
+  unsigned int testMaskOddArray[TEST_MASK_SIZE]  =   {1,  1,  1,  1,   1,  1,  1,  1,     1,  1,  1,  1,     1,  1,  1,  1,    1};
+  constexpr int size = TEST_MASK_SIZE*2;
+  int dstVec[size];
+  int refResult = 34; 
+  int refDstVec[size] ={0,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,   1,1,1,1,1,1,1,1,   1,1,1,1,1,1,1,1,  1,1};  
+
+  nm32s testMaskEven = arrayToInt (testMaskEvenArray, TEST_MASK_SIZE);
+  nm32s testMaskOdd = arrayToInt (testMaskOddArray, TEST_MASK_SIZE);
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvDividedMaskToOffsets_allZeroes_returns0(){
+
+  unsigned int testMaskEvenArray[TEST_MASK_SIZE] = {0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0};
+  unsigned int testMaskOddArray[TEST_MASK_SIZE]  =   {0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0,  0,  0,  0,   0};
+  constexpr int size = TEST_MASK_SIZE*2;
+  int dstVec[size];
+  int refResult = 0; 
+  int refDstVec[size];
+
+
+  for (int i = 0; i < size; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+
+  nm32s testMaskEven = arrayToInt (testMaskEvenArray, TEST_MASK_SIZE);
+  nm32s testMaskOdd = arrayToInt (testMaskOddArray, TEST_MASK_SIZE);
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE*2);//Also check that dstVec is not changed
+
+  return 0;
+}
+
+
+int cnvDividedMaskToOffsets_randomOnes_returns18(){
+
+  unsigned int testMaskEvenArray[TEST_MASK_SIZE] = {0,  0,  1,  1,   0,  1,  0,  1,   0,  1,  0,  1,   1,  1,  0,  1,   0};
+  unsigned int testMaskOddArray[TEST_MASK_SIZE]  =   {0,  0,  1,  1,   0,  1,  0,  1,   0,  1,  0,  1,   1,  1,  0,  1,   0};
+  constexpr int size = TEST_MASK_SIZE*2;
+  int dstVec[size];
+  int refDstVec[size]                            ={        4,1,1,1,     3,1,    3,1,     3,1,    3,1, 1,1,1,1,    3,1 };
+  int refResult = 18; 
+
+  nm32s testMaskEven = arrayToInt (testMaskEvenArray, TEST_MASK_SIZE);
+  nm32s testMaskOdd = arrayToInt (testMaskOddArray, TEST_MASK_SIZE);
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvDividedMaskToOffsets_longDistanceBetweenOnes_returns2(){
+
+  unsigned int testMaskEven[2] = {0x00000002, 0x00000000}; 
+  unsigned int testMaskOdd[2] =  {0x00000000, 0x80000000}; 
+  constexpr int size = 128;
+  int dstVec[size];
+  int refResult = 2;  
+  int refDstVec[size] ={2, 125};
+
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvDividedMaskToOffsets_size0_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  unsigned int testMaskEven = 0xffffffff; 
+  unsigned int testMaskOdd =  0xffffffff; 
+  int dstVec[maxResult];
+  int size = 0;
+  int refResult = 0; 
+  int refDstVec[maxResult];
+
+  for (int i = 0; i < maxResult; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//check that dstVec is not changed
+
+  return 0;
+}
+
+int cnvDividedMaskToOffsets_size2_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  unsigned int testMaskEven = 0xffffffff; 
+  unsigned int testMaskOdd =  0xffffffff; 
+  int dstVec[maxResult] = {0};
+  int size = 2;
+  int refResult = 2; 
+  int refDstVec[maxResult] = {0,1};
+
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMaskEven = %0x\n", testMaskEven);
+  printf("testMaskOdd = %0x\n", testMaskOdd);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}
+
+int cnvDividedMaskToOffsets_size64_resultCorrect(){
+
+  constexpr int maxResult = 128;
+  unsigned int testMaskEven[] = {0x80000000, 0xffffffff}; 
+  unsigned int testMaskOdd[] =  {0x80000000, 0xffffffff}; 
+  int dstVec[maxResult] = {0};
+  int size = 64;
+  int refResult = 2; 
+  int refDstVec[maxResult] = {62,1};
+
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}
+
+
+int cnvDividedMaskToOffsets_size66_resultCorrect(){
+
+  constexpr int maxResult = 128;
+  unsigned int testMaskEven[] = {0x80000000, 0xffffffff}; 
+  unsigned int testMaskOdd[] =  {0x80000000, 0xffffffff}; 
+  int dstVec[maxResult] = {0};
+  int size = 66;
+  int refResult = 4; 
+  int refDstVec[maxResult] = {62, 1, 1, 1};
+
+  int result = cnvDividedMaskToOffsets((nm1*)(&testMaskEven), (nm1*)(&testMaskOdd), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMaskEven[%d] = %0x\n", i, testMaskEven[i]);
+  }
+  for (int i = 0; i < 2; i++){
+    printf("testMaskOdd[%d] = %0x\n", i, testMaskOdd[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);//count > refResult, test that dstVec is changed only in expected values
+
+  return 0;
+}

--- a/test/nmpu0/cnvMaskToIndices/main.cpp
+++ b/test/nmpu0/cnvMaskToIndices/main.cpp
@@ -13,6 +13,7 @@ int cnvMaskToIndices_size0_resultCorrect();
 int cnvMaskToIndices_size1_resultCorrect();
 int cnvMaskToIndices_size32_resultCorrect();
 int cnvMaskToIndices_size33_resultCorrect();
+int cnvMaskToIndices_size33_dstVecExtraElementsNotChanged();
 
 extern "C" int cnvMaskToIndices(nm1* mask, int* indices, int size);
 nm32s arrayToInt (unsigned int* array, int count);
@@ -27,6 +28,7 @@ int main()
   RUN_TEST(cnvMaskToIndices_size1_resultCorrect);
   RUN_TEST(cnvMaskToIndices_size32_resultCorrect);
   RUN_TEST(cnvMaskToIndices_size33_resultCorrect);
+  RUN_TEST(cnvMaskToIndices_size33_dstVecExtraElementsNotChanged);
 
 	return 0;
 }
@@ -108,7 +110,7 @@ int cnvMaskToIndices_allZeroes_returns0(){
 #endif //DEBUG
 
   TEST_ASSERT(result == refResult);
-  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE);//Also check that dstVec is not changed
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, size);//Also check that dstVec is not changed
 
   return 0;
 }
@@ -289,3 +291,74 @@ int cnvMaskToIndices_size33_resultCorrect(){
 
   return 0;
 }
+
+
+int cnvMaskToIndices_size33_dstVecExtraElementsNotChanged(){
+
+  constexpr int maxResult = 64;
+  int dstVec[maxResult] = {0}; 
+  unsigned int testMask[2] = {0xc0000000, 0xffffffff};
+  int size = 33;
+  int refResult = 3; 
+  int refDstVec[maxResult] = {30,31,32};
+
+  dstVec[3] = refDstVec[3] = 777;
+  dstVec[4] = refDstVec[4] = 888;
+
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  //swap extra elements and test one more time
+
+  unsigned int tmp = 0;
+  tmp = refDstVec[3];
+  dstVec[3] = refDstVec[3] = refDstVec[6];
+  dstVec[4] = refDstVec[4] = tmp;
+
+  result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+  return 0;
+}
+

--- a/test/nmpu0/cnvMaskToIndices/main.cpp
+++ b/test/nmpu0/cnvMaskToIndices/main.cpp
@@ -1,0 +1,291 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define		TEST_MASK_SIZE 		17	
+
+int cnvMaskToIndices_allOnes_returns17();
+int cnvMaskToIndices_allZeroes_returns0();
+int cnvMaskToIndices_randomOnes_returns9();
+int cnvMaskToIndices_size0_resultCorrect();
+int cnvMaskToIndices_size1_resultCorrect();
+int cnvMaskToIndices_size32_resultCorrect();
+int cnvMaskToIndices_size33_resultCorrect();
+
+extern "C" int cnvMaskToIndices(nm1* mask, int* indices, int size);
+nm32s arrayToInt (unsigned int* array, int count);
+
+
+int main()
+{
+  RUN_TEST(cnvMaskToIndices_allOnes_returns17);
+  RUN_TEST(cnvMaskToIndices_allZeroes_returns0);
+  RUN_TEST(cnvMaskToIndices_randomOnes_returns9);
+  RUN_TEST(cnvMaskToIndices_size0_resultCorrect);
+  RUN_TEST(cnvMaskToIndices_size1_resultCorrect);
+  RUN_TEST(cnvMaskToIndices_size32_resultCorrect);
+  RUN_TEST(cnvMaskToIndices_size33_resultCorrect);
+
+	return 0;
+}
+
+nm32s arrayToInt (unsigned int* array, int count) 
+{
+  nm32s res = 0;
+  for (int i=0; i<count; i++)
+  {
+    res = res | (array[i] << i);
+  }
+  return res;
+}
+
+
+int cnvMaskToIndices_allOnes_returns17(){
+
+  unsigned int testMaskArray[TEST_MASK_SIZE] = {1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1};
+  constexpr int size = TEST_MASK_SIZE;
+  int dstVec[size];
+  int refResult = 17; 
+  int refDstVec[size]   = {0,1,2,3, 4,5,6,7, 8,9,10,11, 12,13,14,15, 16};
+
+  nm32s testMask = arrayToInt (testMaskArray, TEST_MASK_SIZE);
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvMaskToIndices_allZeroes_returns0(){
+
+  unsigned int testMaskArray[TEST_MASK_SIZE] = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0};
+  constexpr int size = TEST_MASK_SIZE;
+  int dstVec[size];
+  int refDstVec[size];
+  int refResult = 0; 
+
+  for (int i = 0; i < size; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+
+  nm32s testMask = arrayToInt (testMaskArray, TEST_MASK_SIZE);
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE);//Also check that dstVec is not changed
+
+  return 0;
+}
+
+
+int cnvMaskToIndices_randomOnes_returns9(){
+
+  unsigned int testMaskArray[TEST_MASK_SIZE] = {0,0,1,1, 0,1,0,1, 0,1,0,1, 1,1,0,1, 0};
+  constexpr int size = TEST_MASK_SIZE;
+  int dstVec[size];
+  int refDstVec[size] = {2,3,5,7,9,11,12,13,15};
+  int refResult = 9; 
+
+  nm32s testMask = arrayToInt (testMaskArray, TEST_MASK_SIZE);
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvMaskToIndices_size0_resultCorrect(){
+
+  constexpr int maxResult = 32;
+  int dstVec[maxResult] = {0};
+  unsigned int testMask = 0xffffffff;
+  int size = 0;
+  int refDstVec[maxResult] = {0};
+  int refResult = 0; 
+
+  for (int i = 0; i < maxResult; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToIndices_size1_resultCorrect(){
+
+  constexpr int maxResult = 32;
+  int dstVec[maxResult] = {777,777,777}; //some not null values at the beginning
+  unsigned int testMask = 0xffffffff;
+  int size = 1;
+  int refResult = 1; 
+  int refDstVec[maxResult] = {0,777,777};
+
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToIndices_size32_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  int dstVec[maxResult] = {0}; 
+  unsigned int testMask[2] = {0xc0000000, 0xffffffff};
+  int size = 32;
+  int refResult = 2; 
+  int refDstVec[maxResult] = {30,31};
+
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToIndices_size33_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  int dstVec[maxResult] = {0}; 
+  unsigned int testMask[2] = {0xc0000000, 0xffffffff};
+  int size = 33;
+  int refResult = 3; 
+  int refDstVec[maxResult] = {30,31,32};
+
+  int result = cnvMaskToIndices((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}

--- a/test/nmpu0/cnvMaskToOffsets/main.cpp
+++ b/test/nmpu0/cnvMaskToOffsets/main.cpp
@@ -13,6 +13,7 @@ int cnvMaskToOffsets_size0_resultCorrect();
 int cnvMaskToOffsets_size1_resultCorrect();
 int cnvMaskToOffsets_size32_resultCorrect();
 int cnvMaskToOffsets_size33_resultCorrect();
+int cnvMaskToOffsets_size33_dstVecExtraElementsNotChanged();
 
 extern "C" int cnvMaskToOffsets(nm1* mask, int* offsets, int size);
 nm32s arrayToInt (unsigned int* array, int count);
@@ -26,6 +27,7 @@ int main()
   RUN_TEST(cnvMaskToOffsets_size1_resultCorrect);
   RUN_TEST(cnvMaskToOffsets_size32_resultCorrect);
   RUN_TEST(cnvMaskToOffsets_size33_resultCorrect);
+  RUN_TEST(cnvMaskToOffsets_size33_dstVecExtraElementsNotChanged);
 
 	return 0;
 }
@@ -106,7 +108,7 @@ int cnvMaskToOffsets_allZeroes_returns0(){
 #endif //DEBUG
 
   TEST_ASSERT(result == refResult);
-  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE);//Also check that dstVec is not changed
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, size);//Also check that dstVec is not changed
 
   return 0;
 }
@@ -261,6 +263,76 @@ int cnvMaskToOffsets_size33_resultCorrect(){
   int refDstVec[maxResult] = {30,1,1};
 
   int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToOffsets_size33_dstVecExtraElementsNotChanged(){
+
+  constexpr int maxResult = 64;
+  int dstVec[maxResult] = {0}; 
+  unsigned int testMask[2] = {0xc0000000, 0xffffffff};
+  int size = 33;
+  int refResult = 3; 
+  int refDstVec[maxResult] = {30,1,1};
+
+  dstVec[3] = refDstVec[3] = 777;
+  dstVec[4] = refDstVec[4] = 888;
+
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  //swap extra elements and test one more time
+
+  unsigned int tmp = 0;
+  tmp = refDstVec[3];
+  dstVec[3] = refDstVec[3] = refDstVec[6];
+  dstVec[4] = refDstVec[4] = tmp;
+
+  result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
 
 #ifdef DEBUG
   for (int i = 0; i < 2; i++){

--- a/test/nmpu0/cnvMaskToOffsets/main.cpp
+++ b/test/nmpu0/cnvMaskToOffsets/main.cpp
@@ -1,0 +1,288 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define		TEST_MASK_SIZE 		17	
+
+int cnvMaskToOffsets_allOnes_returns17();
+int cnvMaskToOffsets_allZeroes_returns0();
+int cnvMaskToOffsets_randomOnes_returns9();
+int cnvMaskToOffsets_size0_resultCorrect();
+int cnvMaskToOffsets_size1_resultCorrect();
+int cnvMaskToOffsets_size32_resultCorrect();
+int cnvMaskToOffsets_size33_resultCorrect();
+
+extern "C" int cnvMaskToOffsets(nm1* mask, int* offsets, int size);
+nm32s arrayToInt (unsigned int* array, int count);
+
+int main()
+{
+  RUN_TEST(cnvMaskToOffsets_allOnes_returns17);
+  RUN_TEST(cnvMaskToOffsets_allZeroes_returns0);
+  RUN_TEST(cnvMaskToOffsets_randomOnes_returns9);
+  RUN_TEST(cnvMaskToOffsets_size0_resultCorrect);
+  RUN_TEST(cnvMaskToOffsets_size1_resultCorrect);
+  RUN_TEST(cnvMaskToOffsets_size32_resultCorrect);
+  RUN_TEST(cnvMaskToOffsets_size33_resultCorrect);
+
+	return 0;
+}
+
+nm32s arrayToInt (unsigned int* array, int count) 
+{
+  nm32s res = 0;
+  for (int i=0; i<count; i++)
+  {
+    res = res | (array[i] << i);
+  }
+  return res;
+}
+
+int cnvMaskToOffsets_allOnes_returns17(){
+
+  unsigned int testMaskArray[TEST_MASK_SIZE] = {1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1};
+  constexpr int size = TEST_MASK_SIZE;
+  int dstVec[size];
+  int refDstVec[size]               = {0,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1, 1};
+  int refResult = 17; 
+
+  nm32s testMask = arrayToInt (testMaskArray, TEST_MASK_SIZE);
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvMaskToOffsets_allZeroes_returns0(){
+
+  unsigned int testMaskArray[TEST_MASK_SIZE] = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0};
+  constexpr int size = TEST_MASK_SIZE;
+  int dstVec[size];
+  int refDstVec[size];
+  int refResult  = 0; 
+
+  for (int i = 0; i < size; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+
+  nm32s testMask = arrayToInt (testMaskArray, TEST_MASK_SIZE);
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, TEST_MASK_SIZE);//Also check that dstVec is not changed
+
+  return 0;
+}
+
+int cnvMaskToOffsets_randomOnes_returns9(){
+
+  unsigned int testMaskArray[TEST_MASK_SIZE] = {0,0,1,1, 0,1,0,1, 0,1,0,1, 1,1,0,1, 0};
+  constexpr int size = TEST_MASK_SIZE;
+  int dstVec[size];
+  int refDstVec[size]               = {    2,1,   2,  2,   2,  2, 1,1,  2};
+  int refResult = 9; 
+
+  nm32s testMask = arrayToInt (testMaskArray, TEST_MASK_SIZE);
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < size; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, refResult);
+
+  return 0;
+}
+
+int cnvMaskToOffsets_size0_resultCorrect(){
+
+  constexpr int maxResult = 32;
+  int dstVec[maxResult] = {0};
+  unsigned int testMask = 0xffffffff;
+  int size = 0;
+  int refDstVec[maxResult] = {0};
+  int refResult = 0; 
+
+  for (int i = 0; i < maxResult; i++) {
+    dstVec[i] = i;
+    refDstVec[i] = dstVec[i];
+  }
+
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToOffsets_size1_resultCorrect(){
+
+  constexpr int maxResult = 32;
+  int dstVec[maxResult] = {777,777,777}; //some not null values at the beginning
+  unsigned int testMask = 0xffffffff;
+  int size = 1;
+  int refResult = 1; 
+  int refDstVec[maxResult] = {0,777,777};
+
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  printf("testMask = %0x\n", testMask);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToOffsets_size32_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  int dstVec[maxResult] = {0}; 
+  unsigned int testMask[2] = {0xc0000000, 0xffffffff};
+  int size = 32;
+  int refResult = 2; 
+  int refDstVec[maxResult] = {30,1};
+
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}
+
+int cnvMaskToOffsets_size33_resultCorrect(){
+
+  constexpr int maxResult = 64;
+  int dstVec[maxResult] = {0}; 
+  unsigned int testMask[2] = {0xc0000000, 0xffffffff};
+  int size = 33;
+  int refResult = 3; 
+  int refDstVec[maxResult] = {30,1,1};
+
+  int result = cnvMaskToOffsets((nm1*)(&testMask), dstVec, size);
+
+#ifdef DEBUG
+  for (int i = 0; i < 2; i++){
+    printf("testMask[%d] = %0x\n", i, testMask[i]);
+  }
+  printf("size= %d\n", size);
+  printf("result = %d\n", result);
+  printf("dstVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", dstVec[i]);
+  }
+  printf("\r\n");
+
+  printf("refVec: ");
+  for (int i = 0; i < maxResult; i++){
+    printf("%3d ", refDstVec[i]);
+  }
+  printf("\r\n");
+#endif //DEBUG
+
+  TEST_ASSERT(result == refResult);
+  TEST_ARRAYS_EQUALI(dstVec, refDstVec, maxResult);
+
+  return 0;
+}

--- a/test/nmpu0/deselectElementsByIndices/main.cpp
+++ b/test/nmpu0/deselectElementsByIndices/main.cpp
@@ -57,8 +57,8 @@ int deselectElementsByIndices_deselectFloats() {
   float src[FLOAT_ARRAY_SRC_SIZE] = {1.5,3.5,2.5};
   int indices[3]={1,3,2};
   int size = 3;
-  float dst[FLOAT_ARRAY_DST_SIZE]={0.5, 0.0, 0.0, 0.0, 4.5, 5.5, 6.5, 7.5, 8.5};
-  float dstRef[FLOAT_ARRAY_DST_SIZE]={0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5};
+  float dst[FLOAT_ARRAY_DST_SIZE]   ={800.5, 0.0, 0.0, 0.0, 274.5, 721.5, 289.5, 777.5, 118.5};
+  float dstRef[FLOAT_ARRAY_DST_SIZE]={800.5, 1.5, 2.5, 3.5, 274.5, 721.5, 289.5, 777.5, 118.5};
 
   deselectElementsByIndices(src, indices, dst, sizeof32(int), size);
 
@@ -84,8 +84,8 @@ int deselectElementsByIndices_deselectInts() {
   int src[INT_ARRAY_SRC_SIZE]={777, 888, 777};
   int indices[INT_ARRAY_SRC_SIZE + 1]={2,3,2,1};
   int size = 3;
-  int dst[INT_ARRAY_DST_SIZE]={0, 1, 999, 999, 4, 5, 6, 7, 8};
-  int dstRef[INT_ARRAY_DST_SIZE]={0, 1, 777, 888, 4, 5, 6, 7, 8};
+  int dst[INT_ARRAY_DST_SIZE]   ={0xC0DE0001, 0xC0DE0002, 999, 999, 736, 884, 997, 457, 900};
+  int dstRef[INT_ARRAY_DST_SIZE]={0xC0DE0001, 0xC0DE0002, 777, 888, 736, 884, 997, 457, 900};
 
   deselectElementsByIndices(src, indices, dst, sizeof32(int), size);
 
@@ -148,6 +148,7 @@ int deselectElementsByIndices_deselectObjects() {
 
   TEST_ARRAYS_EQUALI(dst, dstRef, OBJECT_ARRAY_DST_SIZE);
 
+  //test one more time
   src[0] = testClass(63,'f',63.5,6300);
   indices[0] = OBJECT_ARRAY_DST_SIZE-1; //copy to last element of dst
   size = 1;

--- a/test/nmpu0/deselectElementsByIndices/main.cpp
+++ b/test/nmpu0/deselectElementsByIndices/main.cpp
@@ -1,0 +1,174 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define		FLOAT_ARRAY_SRC_SIZE 3	
+#define		FLOAT_ARRAY_DST_SIZE 9	
+
+#define		INT_ARRAY_SRC_SIZE 3	
+#define		INT_ARRAY_DST_SIZE 9	
+
+#define		OBJECT_ARRAY_SRC_SIZE 3	
+#define		OBJECT_ARRAY_DST_SIZE 64	
+
+int deselectElementsByIndices_deselectFloats();
+int deselectElementsByIndices_deselectInts();
+int deselectElementsByIndices_deselectObjects();
+
+class testClass {
+public:
+  int a;
+  char b;
+  float c;
+  long d;
+  testClass(int a = 1, char b = 'a', float c = 1.0f, long d = -1):a(a), b(b), c(c), d(d){}
+  void print();
+  friend bool operator!= (const testClass& c1, const testClass& c2);
+ };
+
+void testClass::print () {
+ printf ("%d %c %f %ld\n", a, b, c, d);
+}
+
+bool operator!= (const testClass& c1, const testClass& c2){
+  return (c1.a != c2.a ||
+          c1.b != c2.b ||
+          c1.c != c2.c ||
+          c1.d != c2.d);
+}
+
+extern "C" void deselectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size);
+
+int main()
+{
+
+  RUN_TEST(deselectElementsByIndices_deselectFloats);
+  RUN_TEST(deselectElementsByIndices_deselectInts);
+  RUN_TEST(deselectElementsByIndices_deselectObjects);
+
+	return 0;
+}
+
+
+int deselectElementsByIndices_deselectFloats() {
+
+  float src[FLOAT_ARRAY_SRC_SIZE] = {1.5,3.5,2.5};
+  int indices[3]={1,3,2};
+  int size = 3;
+  float dst[FLOAT_ARRAY_DST_SIZE]={0.5, 0.0, 0.0, 0.0, 4.5, 5.5, 6.5, 7.5, 8.5};
+  float dstRef[FLOAT_ARRAY_DST_SIZE]={0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5};
+
+  deselectElementsByIndices(src, indices, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < FLOAT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < FLOAT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUAL(dst, dstRef, size);
+
+  return 0;
+}
+
+int deselectElementsByIndices_deselectInts() {
+
+  int src[INT_ARRAY_SRC_SIZE]={777, 888, 777};
+  int indices[INT_ARRAY_SRC_SIZE + 1]={2,3,2,1};
+  int size = 3;
+  int dst[INT_ARRAY_DST_SIZE]={0, 1, 999, 999, 4, 5, 6, 7, 8};
+  int dstRef[INT_ARRAY_DST_SIZE]={0, 1, 777, 888, 4, 5, 6, 7, 8};
+
+  deselectElementsByIndices(src, indices, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < INT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < INT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  return 0;
+
+}
+
+
+int deselectElementsByIndices_deselectObjects() {
+
+  testClass src[OBJECT_ARRAY_SRC_SIZE];
+  int indices[3] = {0,1,2};
+  int size = 3;
+  testClass dst[OBJECT_ARRAY_DST_SIZE];
+  testClass dstRef[OBJECT_ARRAY_DST_SIZE];
+
+  src[0] = testClass(1,'a',1.5,100);
+  src[1] = testClass(2,'b',2.5,200);
+  src[2] = testClass(3,'c',3.5,300);
+
+  for (int i = 0; i < OBJECT_ARRAY_DST_SIZE; i++) {
+    dst[i] = testClass(0,'z',0.5,777);
+  }
+
+  for (int i = 0; i < OBJECT_ARRAY_DST_SIZE; i++) {
+    dstRef[i] = dst[i];
+  }
+  dstRef[indices[0]] = src[0];
+  dstRef[indices[1]] = src[1];
+  dstRef[indices[2]] = src[2];
+
+  deselectElementsByIndices(src, indices, dst, sizeof32(testClass), size);
+
+#ifdef DEBUG
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=", i);
+    dst[i].print();
+  }
+  printf(".\n");
+
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=", i);
+    dstRef[i].print();
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, OBJECT_ARRAY_DST_SIZE);
+
+  src[0] = testClass(63,'f',63.5,6300);
+  indices[0] = OBJECT_ARRAY_DST_SIZE-1; //copy to last element of dst
+  size = 1;
+  dstRef[indices[0]] = src[0];
+
+  deselectElementsByIndices(src, indices, dst, sizeof32(testClass), size);
+
+#ifdef DEBUG
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=", i);
+    dst[i].print();
+  }
+  printf(".\n");
+
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=", i);
+    dstRef[i].print();
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, OBJECT_ARRAY_DST_SIZE);
+
+  return 0;
+}

--- a/test/nmpu0/selectElementsByIndices/main.cpp
+++ b/test/nmpu0/selectElementsByIndices/main.cpp
@@ -1,0 +1,177 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define		FLOAT_ARRAY_SRC_SIZE 9	
+#define		FLOAT_ARRAY_DST_SIZE 3	
+
+#define		INT_ARRAY_SRC_SIZE 9	
+#define		INT_ARRAY_DST_SIZE 3	
+
+#define		OBJECT_ARRAY_SRC_SIZE 64	
+#define		OBJECT_ARRAY_DST_SIZE 3	
+
+int selectElementsByIndices_selectFloats();
+int selectElementsByIndices_selectInts();
+int selectElementsByIndices_selectObjects();
+
+class testClass {
+public:
+  int a;
+  char b;
+  float c;
+  long d;
+  testClass(int a = 1, char b = 'a', float c = 1.0f, long d = -1):a(a), b(b), c(c), d(d){}
+  void print();
+  friend bool operator!= (const testClass& c1, const testClass& c2);
+ };
+
+void testClass::print () {
+ printf ("%d %c %f %ld\n", a, b, c, d);
+}
+
+bool operator!= (const testClass& c1, const testClass& c2){
+  return (c1.a != c2.a ||
+          c1.b != c2.b ||
+          c1.c != c2.c ||
+          c1.d != c2.d);
+}
+
+extern "C" void selectElementsByIndices(void* src, int* indices, void* dst, int sizeOfElementInt, int size);
+
+int main()
+{
+
+  RUN_TEST(selectElementsByIndices_selectFloats);
+  RUN_TEST(selectElementsByIndices_selectInts);
+  RUN_TEST(selectElementsByIndices_selectObjects);
+
+	return 0;
+}
+
+
+int selectElementsByIndices_selectFloats() {
+
+  float src[FLOAT_ARRAY_SRC_SIZE]={0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5};
+  int indices[3]={1,3,2};
+  float dst[FLOAT_ARRAY_DST_SIZE];
+  float dstRef[FLOAT_ARRAY_DST_SIZE]={1.5,3.5,2.5};
+  int size = 3;
+
+	for (int i = 0; i < FLOAT_ARRAY_DST_SIZE; i++) {
+		dst[i] = 0;
+	}
+
+  selectElementsByIndices(src, indices, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < FLOAT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < FLOAT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUAL(dst, dstRef, size);
+
+  return 0;
+}
+
+int selectElementsByIndices_selectInts() {
+
+  int src[INT_ARRAY_SRC_SIZE]={0, 1, 2, 3, 4, 5, 6, 7, 8};
+  int indices[4]={2,3,2,1};
+  int dst[INT_ARRAY_DST_SIZE];
+  int dstRef[INT_ARRAY_DST_SIZE]={2, 3, 2};
+  int size = 3;
+
+	for (int i = 0; i < INT_ARRAY_DST_SIZE; i++) {
+		dst[i] = 0;
+	}
+
+  selectElementsByIndices(src, indices, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < INT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < INT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  return 0;
+
+}
+
+
+int selectElementsByIndices_selectObjects() {
+
+  testClass src[OBJECT_ARRAY_SRC_SIZE];
+  int indices[3] = {0,1,2};
+  testClass dst[OBJECT_ARRAY_DST_SIZE];
+  testClass dstRef[OBJECT_ARRAY_DST_SIZE];
+  int size = 3;
+
+  src[0] = testClass(1,'a',1.5,100);
+  src[1] = testClass(2,'b',2.5,200);
+  src[2] = testClass(3,'c',3.5,300);
+  src[3] = testClass(4,'d',4.5,400);
+  src[4] = testClass(5,'e',5.5,500);
+  src[63] = testClass(63,'f',63.5,6300);
+
+  dstRef[0] = src[indices[0]];
+  dstRef[1] = src[indices[1]];
+  dstRef[2] = src[indices[2]];
+
+  selectElementsByIndices(src, indices, dst, sizeof32(testClass), size);
+
+#ifdef DEBUG
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=", i);
+    dst[i].print();
+  }
+  printf(".\n");
+
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=", i);
+    dstRef[i].print();
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  indices[0] = 63;
+  dstRef[0] = src[indices[0]];
+  size = 1;
+
+  selectElementsByIndices(src, indices, dst, sizeof32(testClass), size);
+
+#ifdef DEBUG
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=", i);
+    dst[i].print();
+  }
+  printf(".\n");
+
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=", i);
+    dstRef[i].print();
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  return 0;
+}

--- a/test/nmpu0/selectElementsByIndices/main.cpp
+++ b/test/nmpu0/selectElementsByIndices/main.cpp
@@ -16,6 +16,7 @@
 int selectElementsByIndices_selectFloats();
 int selectElementsByIndices_selectInts();
 int selectElementsByIndices_selectObjects();
+int selectElementsByIndices_dstExtraElementsNotChanged();
 
 class testClass {
 public:
@@ -47,6 +48,7 @@ int main()
   RUN_TEST(selectElementsByIndices_selectFloats);
   RUN_TEST(selectElementsByIndices_selectInts);
   RUN_TEST(selectElementsByIndices_selectObjects);
+  RUN_TEST(selectElementsByIndices_dstExtraElementsNotChanged);
 
 	return 0;
 }
@@ -174,4 +176,55 @@ int selectElementsByIndices_selectObjects() {
   TEST_ARRAYS_EQUALI(dst, dstRef, size);
 
   return 0;
+}
+
+int selectElementsByIndices_dstExtraElementsNotChanged() {
+  constexpr unsigned int srcSize = 9;
+  constexpr unsigned int dstSize = 5;
+  int src[srcSize]={0, 1, 2, 3, 4, 5, 6, 7, 8};
+  int indices[4]={2,3,2,1};
+  int dst[dstSize]={1, 2, 3, 0xC0DE0777, 0xC0DE0922};
+  int dstRef[dstSize]={2, 3, 2, 0xC0DE0777, 0xC0DE0922};
+  int size = 3;
+
+  selectElementsByIndices(src, indices, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < dstSize; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < dstSize; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, dstSize);
+
+  //swap extra elements and test one more time
+  unsigned int tmp = 0;
+  tmp = dstRef[3]; 
+  dst[3] = dstRef[3] = dstRef[4];
+  dst[4] = dstRef[4] = tmp;
+
+  selectElementsByIndices(src, indices, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < dstSize; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < dstSize; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, dstSize);
+
+  return 0;
+
 }

--- a/test/nmpu0/selectElementsByOffsets/main.cpp
+++ b/test/nmpu0/selectElementsByOffsets/main.cpp
@@ -16,6 +16,7 @@
 int selectElementsByOffsets_selectFloats();
 int selectElementsByOffsets_selectInts();
 int selectElementsByOffsets_selectObjects();
+int selectElementsByOffsets_dstExtraElementsNotChanged();
 
 class testClass {
 public:
@@ -47,6 +48,7 @@ int main()
   RUN_TEST(selectElementsByOffsets_selectFloats);
   RUN_TEST(selectElementsByOffsets_selectInts);
   RUN_TEST(selectElementsByOffsets_selectObjects);
+  RUN_TEST(selectElementsByOffsets_dstExtraElementsNotChanged);
 
 	return 0;
 }
@@ -177,4 +179,58 @@ int selectElementsByOffsets_selectObjects() {
   TEST_ARRAYS_EQUALI(dst, dstRef, size);
 
   return 0;
+}
+
+
+
+int selectElementsByOffsets_dstExtraElementsNotChanged() {
+
+  constexpr unsigned int srcSize = 9;
+  constexpr unsigned int dstSize = 5;
+  int src[srcSize]={0, 1, 2, 3, 4, 5, 6, 7, 8};
+  int offsets[4]={2,3,2,1};
+  int dst[dstSize]={1, 2, 3, 0xC0DE0777, 0xC0DE0922};
+  int dstRef[dstSize]={2, 5, 7, 0xC0DE0777, 0xC0DE0922};
+  int size = 3;
+
+  selectElementsByOffsets(src, offsets, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < dstSize; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < dstSize; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, dstSize);
+
+
+  //swap extra elements and test one more time
+  unsigned int tmp = 0;
+  tmp = dstRef[3]; 
+  dst[3] = dstRef[3] = dstRef[4];
+  dst[4] = dstRef[4] = tmp;
+
+  selectElementsByOffsets(src, offsets, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < dstSize; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < dstSize; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, dstSize);
+  return 0;
+
 }

--- a/test/nmpu0/selectElementsByOffsets/main.cpp
+++ b/test/nmpu0/selectElementsByOffsets/main.cpp
@@ -1,0 +1,180 @@
+#include "nmpp.h"
+#include "time.h"
+#include <stdio.h>
+#include "demo3d_common.h"
+#include "tests.h"
+
+#define		FLOAT_ARRAY_SRC_SIZE 9	
+#define		FLOAT_ARRAY_DST_SIZE 3	
+
+#define		INT_ARRAY_SRC_SIZE 9	
+#define		INT_ARRAY_DST_SIZE 3	
+
+#define		OBJECT_ARRAY_SRC_SIZE 64	
+#define		OBJECT_ARRAY_DST_SIZE 3	
+
+int selectElementsByOffsets_selectFloats();
+int selectElementsByOffsets_selectInts();
+int selectElementsByOffsets_selectObjects();
+
+class testClass {
+public:
+  int a;
+  char b;
+  float c;
+  long d;
+  testClass(int a = 1, char b = 'a', float c = 1.0f, long d = -1):a(a), b(b), c(c), d(d){}
+  void print();
+  friend bool operator!= (const testClass& c1, const testClass& c2);
+ };
+
+void testClass::print () {
+ printf ("%d %c %f %ld\n", a, b, c, d);
+}
+
+bool operator!= (const testClass& c1, const testClass& c2){
+  return (c1.a != c2.a ||
+          c1.b != c2.b ||
+          c1.c != c2.c ||
+          c1.d != c2.d);
+}
+
+extern "C" void selectElementsByOffsets(void* src, int* offsets, void* dst, int sizeOfElementInt, int size);
+
+int main()
+{
+
+  RUN_TEST(selectElementsByOffsets_selectFloats);
+  RUN_TEST(selectElementsByOffsets_selectInts);
+  RUN_TEST(selectElementsByOffsets_selectObjects);
+
+	return 0;
+}
+
+
+int selectElementsByOffsets_selectFloats() {
+
+  float src[FLOAT_ARRAY_SRC_SIZE]={0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5};
+  int offsets[3]={1,3,2};
+  float dst[FLOAT_ARRAY_DST_SIZE];
+  float dstRef[FLOAT_ARRAY_DST_SIZE]={1.5,4.5,6.5};
+  int size = 3;
+
+	for (int i = 0; i < FLOAT_ARRAY_DST_SIZE; i++) {
+		dst[i] = 0;
+	}
+
+  selectElementsByOffsets(src, offsets, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < FLOAT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < FLOAT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUAL(dst, dstRef, size);
+
+  return 0;
+}
+
+int selectElementsByOffsets_selectInts() {
+
+  int src[INT_ARRAY_SRC_SIZE]={0, 1, 2, 3, 4, 5, 6, 7, 8};
+  int offsets[4]={2,3,2,1};
+  int dst[INT_ARRAY_DST_SIZE];
+  int dstRef[INT_ARRAY_DST_SIZE]={2, 5, 7};
+  int size = 3;
+
+	for (int i = 0; i < INT_ARRAY_DST_SIZE; i++) {
+		dst[i] = 0;
+	}
+
+  selectElementsByOffsets(src, offsets, dst, sizeof32(int), size);
+
+#ifdef DEBUG
+  for(int i=0; i < INT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=%d\n", i, dst[i]);
+  }
+  printf(".\n");
+
+  for(int i=0; i < INT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=%d\n", i, dstRef[i]);
+  }
+  printf(".\n");
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  return 0;
+
+}
+
+int selectElementsByOffsets_selectObjects() {
+
+  testClass src[OBJECT_ARRAY_SRC_SIZE];
+  int offsets[3] = {0,1,2};
+  testClass dst[OBJECT_ARRAY_DST_SIZE];
+  testClass dstRef[OBJECT_ARRAY_DST_SIZE];
+  int size = 3;
+
+  src[0] = testClass(1,'a',1.5,100);
+  src[1] = testClass(2,'b',2.5,200);
+  src[2] = testClass(3,'c',3.5,300);
+  src[3] = testClass(4,'d',4.5,400);
+  src[4] = testClass(5,'e',5.5,500);
+  src[63] = testClass(63,'f',63.5,6300);
+
+  int curOffset = offsets[0];
+  dstRef[0] = src[curOffset];
+  curOffset = curOffset + offsets[1];
+  dstRef[1] = src[curOffset];
+  curOffset = curOffset + offsets[2];
+  dstRef[2] = src[curOffset];
+
+  selectElementsByOffsets(src, offsets, dst, sizeof32(testClass), size);
+
+#ifdef DEBUG
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=", i);
+    dst[i].print();
+  }
+  printf(".\n");
+
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=", i);
+    dstRef[i].print();
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  offsets[0] = 63;
+  curOffset = offsets[0];
+  dstRef[0] = src[curOffset];
+  size = 1;
+
+  selectElementsByOffsets(src, offsets, dst, sizeof32(testClass), size);
+
+#ifdef DEBUG
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dst[%d]=", i);
+    dst[i].print();
+  }
+  printf(".\n");
+
+  for(int i=0; i < OBJECT_ARRAY_DST_SIZE; i++){
+    printf("dstRef[%d]=", i);
+    dstRef[i].print();
+  }
+#endif //DEBUG
+
+  TEST_ARRAYS_EQUALI(dst, dstRef, size);
+
+  return 0;
+}

--- a/test/perf/mai/Makefile
+++ b/test/perf/mai/Makefile
@@ -8,6 +8,7 @@ all_mc12101: configure0 configure1
 configure0 config_nmpu0:
 	testperf config -i ../../../include/nmgltex_nm0.h -b make_mc12101_nmpu0-ld
 	testperf config -i ../../../include/service.h -b make_mc12101_nmpu0-ld
+	testperf config -i ../../../include/filter.h -b make_mc12101_nmpu0-ld
 
 configure1 config_nmpu1:
 	testperf config -i ../../../include/nmgltex_nm1.h -b make_mc12101_nmpu1-ld --point fixed	

--- a/test/perf/mai/make_mc12101_nmpu0-ld/main.cpp
+++ b/test/perf/mai/make_mc12101_nmpu0-ld/main.cpp
@@ -5,6 +5,7 @@
 #include "stdlib.h"
 #include "demo3d_nm0.h"
 #include "service.h"
+#include "filter.h"
 
 __attribute__((section(".mem_bank0"))) long long im0[1];
 __attribute__((section(".mem_bank1"))) long long im1[1];


### PR DESCRIPTION
Add cpp and asm implementations for following filter functions:

* cmpEqC_f.asm
* cmpEqV_f.asm
* cmpGtC_f.asm
* cmpGtV_f.asm
* cmpGteC_f.asm
* cmpGteV_f.asm
* cmpLtC_f.asm
* cmpLtV_f.asm
* cmpLteC_f.asm
* cmpLteV_f.asm
* cmpNeC_f.asm
* cmpNeV_f.asm
* cnvDividedMaskToIndices.asm
* cnvDividedMaskToOffsets.asm
* cnvMaskToIndices.asm
* cnvMaskToOffsets.asm
* selectElementsByIndices.asm
* selectElementsByOffsets.asm
* deselectElementsByIndices.asm - new function, reverse function for
  selectElementsByIndices

Implementations were made for nmpu0.
Also add functional tests and testperf tests for filter functions.
Modify make_mc12101_nmpu0-ld/main.cpp and Makefile int test/perf/mai to add filter
function testperf tests.