### PR TITLE
Use service.h instead of demo3d_nm0.h in pc-versions of repackToPrimitives_t* functions

### DIFF
--- a/src_proc0/pc/repackToPrimitives_t.cpp
+++ b/src_proc0/pc/repackToPrimitives_t.cpp
@@ -1,5 +1,5 @@
 #include "nmpp.h"
-#include "demo3d_nm0.h"
+#include "service.h"
 
 #include "nmblas.h"
 

--- a/src_proc0/pc/repackToPrimitives_tf.cpp
+++ b/src_proc0/pc/repackToPrimitives_tf.cpp
@@ -1,5 +1,5 @@
 #include "nmpp.h"
-#include "demo3d_nm0.h"
+#include "service.h"
 
 #include "nmblas.h"
 

--- a/src_proc0/pc/repackToPrimitives_ts.cpp
+++ b/src_proc0/pc/repackToPrimitives_ts.cpp
@@ -1,5 +1,5 @@
 #include "nmpp.h"
-#include "demo3d_nm0.h"
+#include "service.h"
 
 #include "nmblas.h"
 


### PR DESCRIPTION
service.h declares repack functions as extern "C", demo3d-nm0.h doesn't
containg repackToPrimitives_t* declarations. So x86 version of 2nmc-demo-gcc didn't link