### PR TITLE
Move allmem init2cntxt

### DIFF
--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -330,7 +330,7 @@ public:
 
 	void init(){
 		int i;
-		int heap;
+	/*	int heap;
 		heap = getHeap();
 		
 		setHeap(12);
@@ -342,7 +342,7 @@ public:
     	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
     	}
 		setHeap(heap);
-
+ 	*/
 		
 		unpackAlignment=4;
 		packAlignment=4;

--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -330,6 +330,20 @@ public:
 
 	void init(){
 		int i;
+		int heap;
+		heap = getHeap();
+		
+		setHeap(12);
+
+    	polygon.stipple.pattern = (NMGLubyte*)halMalloc32(NMGL_POLIGON_STIPPLE_SIDE_UBYTES*(NMGL_POLIGON_STIPPLE_SIDE_UBYTES>>3)*sizeof32(NMGLubyte)); 
+    	
+    	if(polygon.stipple.pattern == 0)
+    	{
+    	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
+    	}
+		setHeap(heap);
+
+		
 		unpackAlignment=4;
 		packAlignment=4;
 		

--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -330,20 +330,7 @@ public:
 
 	void init(){
 		int i;
-	/*	int heap;
-		heap = getHeap();
-		
-		setHeap(12);
-
-    	polygon.stipple.pattern = (NMGLubyte*)halMalloc32(NMGL_POLIGON_STIPPLE_SIDE_UBYTES*(NMGL_POLIGON_STIPPLE_SIDE_UBYTES>>3)*sizeof32(NMGLubyte)); 
-    	
-    	if(polygon.stipple.pattern == 0)
-    	{
-    	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
-    	}
-		setHeap(heap);
- 	*/
-		
+	
 		unpackAlignment=4;
 		packAlignment=4;
 		

--- a/include/nmgltex_nm0.h
+++ b/include/nmgltex_nm0.h
@@ -94,7 +94,7 @@ struct NMGL_Context_NM0_Texture {
 	
 	//NMGLubyte * palettes_pointer;
 	NMGLubyte * palette_pointers[(NMGL_MAX_TEX_OBJECTS+1)];//0-shared
-	void init_elements(){
+	void init_units_objects(){
 		//==========TEX_UNITS_INIT====================================
 		INIT_TEX_UNITS();
 //==========TEX_OBJ_INIT====================================

--- a/include/nmgltex_nm0.h
+++ b/include/nmgltex_nm0.h
@@ -104,28 +104,6 @@ struct NMGL_Context_NM0_Texture {
 
 	void init(){
 	
-		//firstFreeTexByte=NULL;
-		//palettes_pointer = init_mem_palettes();
-	/*	int heap;
-		heap = getHeap();
-
-		setHeap(12);		
-		palette_pointers[0] = (NMGLubyte*)halMalloc32(NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE*(NMGL_MAX_TEX_OBJECTS+1)*sizeof32(NMGLubyte)); 
-    	if(palette_pointers[0] == 0)
-    	{
-    	    printf("Error! Cant allocate texture palette memory!");
-    	}
-		paletts_widths_pointers[0] = (unsigned int *)halMalloc32((NMGL_MAX_TEX_OBJECTS+1)*sizeof32(unsigned int)); 
-        if(paletts_widths_pointers[0] == 0)
-        {
-            printf("Error! Cant allocate texture palette width memory!");
-        }
-		setHeap(heap);
-	*/
-
-
-
-
 		shared_palette_enabled = NMGL_FALSE;
 		activeTexUnit = NMGL_TEXTURE0;
 		activeTexUnitIndex = 0;
@@ -140,46 +118,14 @@ struct NMGL_Context_NM0_Texture {
 			texcoordArray[i].type = NMGL_FLOAT;
 			texcoordArray[i].enabled = NMGL_FALSE;
 		}
-/*
-		for (int i = 0; i < NMGL_MAX_TEX_OBJECTS+1; i++)
-		{
-			paletts_widths[i]=1;
-			if(i == 0)
-			{
-				palette_pointers[i]=init_mem_palettes();
-			}
-			else{
-				palette_pointers[i]=(NMGLubyte*)palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
-			}
-			for(int j=0;j<3;j++)
-			{
-				*((NMGLubyte*)palette_pointers[i]+j)=0x1;
-			}
-		}
-*/
-//INIT_PALETTE_MEMORY_POINTERS();
-//palette_pointers[0] = palettes_p;
-//paletts_widths_pointers[0] = palettes_widths_p;
-/*
-for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
-{
-	palette_pointers[i] = (NMGLubyte*)palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
-	paletts_widths_pointers[i] = (unsigned int*)((unsigned int*)paletts_widths_pointers[0]+i);
-}
-*/
-//halSyncAddr(palette_pointers[0], 1);
-//halSyncAddr(paletts_widths_pointers[0], 1);
-
-
 		textureEnabled = 0;
 	}
 	void use_shared_palette()
 	{
 		for (int i = 0; i < NMGL_MAX_TEX_OBJECTS; i++)
 		{
-			//texObjects[i].palette.setColors(get_shared_palette_p());
+			
 			texObjects[i].palette.colors=get_shared_palette_p();
-			//texObjects[i].palette.setWidth_p(&paletts_widths[0]);
 			texObjects[i].palette.width = paletts_widths_pointers[0];
 		}
 	}

--- a/include/nmgltex_nm0.h
+++ b/include/nmgltex_nm0.h
@@ -3,7 +3,7 @@
 
 #include "demo3d_common.h"
 #include "nmgltex_common.h"
-#include "hal.h"
+#include "hal.h" 
 #include "hal_target.h"
 
 //extern NMGLubyte* init_mem_palettes();
@@ -100,7 +100,25 @@ struct NMGL_Context_NM0_Texture {
 	
 		//firstFreeTexByte=NULL;
 		//palettes_pointer = init_mem_palettes();
+		int heap;
+		heap = getHeap();
+		setHeap(12);
 		
+		palette_pointers[0] = (NMGLubyte*)halMalloc32(NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE*(NMGL_MAX_TEX_OBJECTS+1)*sizeof32(NMGLubyte)); 
+    	if(palette_pointers[0] == 0)
+    	{
+    	    printf("Error! Cant allocate texture palette memory!");
+    	}
+		paletts_widths_pointers[0] = (unsigned int *)halMalloc32((NMGL_MAX_TEX_OBJECTS+1)*sizeof32(unsigned int)); 
+        if(paletts_widths_pointers[0] == 0)
+        {
+            printf("Error! Cant allocate texture palette width memory!");
+        }
+	setHeap(heap);
+
+
+
+
 		shared_palette_enabled = NMGL_FALSE;
 		activeTexUnit = NMGL_TEXTURE0;
 		activeTexUnitIndex = 0;
@@ -133,8 +151,8 @@ struct NMGL_Context_NM0_Texture {
 		}
 */
 //INIT_PALETTE_MEMORY_POINTERS();
-palette_pointers[0] = palettes_p;
-paletts_widths_pointers[0] = palettes_widths_p;
+//palette_pointers[0] = palettes_p;
+//paletts_widths_pointers[0] = palettes_widths_p;
 
 for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
 {

--- a/include/nmgltex_nm0.h
+++ b/include/nmgltex_nm0.h
@@ -94,16 +94,22 @@ struct NMGL_Context_NM0_Texture {
 	
 	//NMGLubyte * palettes_pointer;
 	NMGLubyte * palette_pointers[(NMGL_MAX_TEX_OBJECTS+1)];//0-shared
-	
+	void init_elements(){
+		//==========TEX_UNITS_INIT====================================
+		INIT_TEX_UNITS();
+//==========TEX_OBJ_INIT====================================
+		INIT_TEX_OBJECTS();
+		
+	}
 
 	void init(){
 	
 		//firstFreeTexByte=NULL;
 		//palettes_pointer = init_mem_palettes();
-		int heap;
+	/*	int heap;
 		heap = getHeap();
-		setHeap(12);
-		
+
+		setHeap(12);		
 		palette_pointers[0] = (NMGLubyte*)halMalloc32(NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE*(NMGL_MAX_TEX_OBJECTS+1)*sizeof32(NMGLubyte)); 
     	if(palette_pointers[0] == 0)
     	{
@@ -114,7 +120,8 @@ struct NMGL_Context_NM0_Texture {
         {
             printf("Error! Cant allocate texture palette width memory!");
         }
-	setHeap(heap);
+		setHeap(heap);
+	*/
 
 
 
@@ -153,20 +160,17 @@ struct NMGL_Context_NM0_Texture {
 //INIT_PALETTE_MEMORY_POINTERS();
 //palette_pointers[0] = palettes_p;
 //paletts_widths_pointers[0] = palettes_widths_p;
-
+/*
 for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
 {
 	palette_pointers[i] = (NMGLubyte*)palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
 	paletts_widths_pointers[i] = (unsigned int*)((unsigned int*)paletts_widths_pointers[0]+i);
 }
+*/
 //halSyncAddr(palette_pointers[0], 1);
 //halSyncAddr(paletts_widths_pointers[0], 1);
 
-//==========TEX_UNITS_INIT====================================
-		INIT_TEX_UNITS();
-//==========TEX_OBJ_INIT====================================
-		INIT_TEX_OBJECTS();
-		
+
 		textureEnabled = 0;
 	}
 	void use_shared_palette()

--- a/include/nmgltex_nm1.h
+++ b/include/nmgltex_nm1.h
@@ -130,11 +130,7 @@ unsigned int palette_is_shared;
 
 DEBUG_PRINT(("got palette_pointer:0x%x",palette_pointers[0]));
 DEBUG_PRINT(("got palette_width pointer:0x%x",paletts_widths_pointers[0]));
-for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
-{
-	palette_pointers[i] = (NMGLubyte*)palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
-	paletts_widths_pointers[i] = (unsigned int*)((unsigned int*)paletts_widths_pointers[0]+i);
-}
+
 INIT_TEX_UNITS();
 INIT_TEX_OBJECTS(); 
 /*for(int i = 0; i < NMGL_MAX_TEX_OBJECTS; i++) 

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -63,9 +63,9 @@ extern "C" {
 
 extern  NMGLubyte* mipmap; //texture memory
 
-NMGLubyte* palettes_p; // texture palette memory
-unsigned int* palettes_widths_p; // texture palettes widths memory
-NMGLubyte* PolygonsStipplePattern_p;
+//NMGLubyte* palettes_p; // texture palette memory
+//unsigned int* palettes_widths_p; // texture palettes widths memory
+//NMGLubyte* PolygonsStipplePattern_p;
 int counter = 0;
 
 #define PRINT_ADDR(a) printf(#a"=%p\n", a)
@@ -118,7 +118,7 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		synchroData->init();
 		halSyncAddr(synchroData, 1);
 //TEXTURE -- PALETTE MEM INITIALIZATION
-		
+		/*
 		setHeap(12);
 		try
     	{
@@ -129,10 +129,11 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
     	    printf("Error! Cant allocate texture palette memory!");
     	    return -1;
     	}
-    	DEBUG_PRINT(("allocated palette_pointer:0x%x",palettes_p));
-		halSyncAddr(palettes_p, 1);
+		*/
+    	//DEBUG_PRINT(("allocated palette_pointer:0x%x",palettes_p));
+		//halSyncAddr(palettes_p, 1);
 		
-		 try
+	/*	 try
         {
            palettes_widths_p = (unsigned int *)myMallocT<unsigned int>((NMGL_MAX_TEX_OBJECTS+1)); 
         }
@@ -140,9 +141,9 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
         {
             printf("Error! Cant allocate texture palette width memory!");
             return -1;
-        }
-		halSyncAddr(palettes_widths_p, 1);
-		try
+        }*/
+		//halSyncAddr(palettes_widths_p, 1);
+		/*try
     	{
     	   PolygonsStipplePattern_p = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_POLIGON_STIPPLE_SIDE_UBYTES*(NMGL_POLIGON_STIPPLE_SIDE_UBYTES>>3)); 
     	}
@@ -150,15 +151,19 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
     	{
     	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
     	    return -1;
-    	}
-		halSyncAddr(PolygonsStipplePattern_p, 1);
+    	}*/
+		//halSyncAddr(PolygonsStipplePattern_p, 1);
 		
 		setHeap(7);
 		NMGL_Context_NM0::create();
 		cntxt = NMGL_Context_NM0::getContext();
 		cntxt->synchro.init(synchroData);		
+		
+		halSyncAddr(cntxt->texState.palette_pointers[0], 1);
+		halSyncAddr(cntxt->texState.paletts_widths_pointers[0], 1);
+		halSyncAddr(cntxt->polygon.stipple.pattern, 1);
 
-		cntxt->polygon.stipple.pattern = PolygonsStipplePattern_p;
+		//cntxt->polygon.stipple.pattern = PolygonsStipplePattern_p;
 
 		setHeap(10);
 		PolygonsArray* trianData = myMallocT<PolygonsArray>(36);

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -159,10 +159,35 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		cntxt = NMGL_Context_NM0::getContext();
 		cntxt->synchro.init(synchroData);		
 		
+		setHeap(12);		
+		cntxt->texState.palette_pointers[0] = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE*(NMGL_MAX_TEX_OBJECTS+1)); 
+    	if(cntxt->texState.palette_pointers[0] == 0)
+    	{
+    	    printf("Error! Cant allocate texture palette memory!");
+    	}
+		cntxt->texState.paletts_widths_pointers[0] = (unsigned int *)myMallocT<unsigned int>((NMGL_MAX_TEX_OBJECTS+1)); 
+        if(cntxt->texState.paletts_widths_pointers[0] == 0)
+        {
+            printf("Error! Cant allocate texture palette width memory!");
+        }
+		for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
+		{
+			cntxt->texState.palette_pointers[i] = (NMGLubyte*)cntxt->texState.palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
+			cntxt->texState.paletts_widths_pointers[i] = (unsigned int*)((unsigned int*)cntxt->texState.paletts_widths_pointers[0]+i);
+		}
+
+		cntxt->polygon.stipple.pattern = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_POLIGON_STIPPLE_SIDE_UBYTES*(NMGL_POLIGON_STIPPLE_SIDE_UBYTES>>3)); 
+    	
+    	if(cntxt->polygon.stipple.pattern == 0)
+    	{
+    	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
+    	}
+
+
 		halSyncAddr(cntxt->texState.palette_pointers[0], 1);
 		halSyncAddr(cntxt->texState.paletts_widths_pointers[0], 1);
 		halSyncAddr(cntxt->polygon.stipple.pattern, 1);
-
+		cntxt->texState.init_elements();
 		//cntxt->polygon.stipple.pattern = PolygonsStipplePattern_p;
 
 		setHeap(10);

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -63,9 +63,6 @@ extern "C" {
 
 extern  NMGLubyte* mipmap; //texture memory
 
-//NMGLubyte* palettes_p; // texture palette memory
-//unsigned int* palettes_widths_p; // texture palettes widths memory
-//NMGLubyte* PolygonsStipplePattern_p;
 int counter = 0;
 
 #define PRINT_ADDR(a) printf(#a"=%p\n", a)
@@ -117,43 +114,6 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		//PRINT_ADDR(synchroData);
 		synchroData->init();
 		halSyncAddr(synchroData, 1);
-//TEXTURE -- PALETTE MEM INITIALIZATION
-		/*
-		setHeap(12);
-		try
-    	{
-    	   palettes_p = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE*(NMGL_MAX_TEX_OBJECTS+1)); 
-    	}
-    	catch(int& e)
-    	{
-    	    printf("Error! Cant allocate texture palette memory!");
-    	    return -1;
-    	}
-		*/
-    	//DEBUG_PRINT(("allocated palette_pointer:0x%x",palettes_p));
-		//halSyncAddr(palettes_p, 1);
-		
-	/*	 try
-        {
-           palettes_widths_p = (unsigned int *)myMallocT<unsigned int>((NMGL_MAX_TEX_OBJECTS+1)); 
-        }
-        catch(int& e)
-        {
-            printf("Error! Cant allocate texture palette width memory!");
-            return -1;
-        }*/
-		//halSyncAddr(palettes_widths_p, 1);
-		/*try
-    	{
-    	   PolygonsStipplePattern_p = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_POLIGON_STIPPLE_SIDE_UBYTES*(NMGL_POLIGON_STIPPLE_SIDE_UBYTES>>3)); 
-    	}
-    	catch(int& e)
-    	{
-    	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
-    	    return -1;
-    	}*/
-		//halSyncAddr(PolygonsStipplePattern_p, 1);
-		
 		setHeap(7);
 		NMGL_Context_NM0::create();
 		cntxt = NMGL_Context_NM0::getContext();
@@ -161,15 +121,15 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		
 		setHeap(12);		
 		cntxt->texState.palette_pointers[0] = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE*(NMGL_MAX_TEX_OBJECTS+1)); 
-    	if(cntxt->texState.palette_pointers[0] == 0)
-    	{
-    	    printf("Error! Cant allocate texture palette memory!");
-    	}
+		if(cntxt->texState.palette_pointers[0] == 0)
+		{
+		    printf("Error! Cant allocate texture palette memory!");
+		}
 		cntxt->texState.paletts_widths_pointers[0] = (unsigned int *)myMallocT<unsigned int>((NMGL_MAX_TEX_OBJECTS+1)); 
-        if(cntxt->texState.paletts_widths_pointers[0] == 0)
-        {
-            printf("Error! Cant allocate texture palette width memory!");
-        }
+		 if(cntxt->texState.paletts_widths_pointers[0] == 0)
+		 {
+		     printf("Error! Cant allocate texture palette width memory!");
+		 }
 		for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
 		{
 			cntxt->texState.palette_pointers[i] = (NMGLubyte*)cntxt->texState.palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
@@ -177,17 +137,17 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		}
 
 		cntxt->polygon.stipple.pattern = (NMGLubyte*)myMallocT<NMGLubyte>(NMGL_POLIGON_STIPPLE_SIDE_UBYTES*(NMGL_POLIGON_STIPPLE_SIDE_UBYTES>>3)); 
-    	
-    	if(cntxt->polygon.stipple.pattern == 0)
-    	{
-    	    printf("Error! Cant allocate PolygonsStipplePattern memory!");
-    	}
+
+		if(cntxt->polygon.stipple.pattern == 0)
+		{
+		    printf("Error! Cant allocate PolygonsStipplePattern memory!");
+		}
 
 
 		halSyncAddr(cntxt->texState.palette_pointers[0], 1);
 		halSyncAddr(cntxt->texState.paletts_widths_pointers[0], 1);
 		halSyncAddr(cntxt->polygon.stipple.pattern, 1);
-		cntxt->texState.init_elements();
+		cntxt->texState.init_units_objects();
 		//cntxt->polygon.stipple.pattern = PolygonsStipplePattern_p;
 
 		setHeap(10);

--- a/nmglvs_mc12101-gcc/src_nmc1/nmglvsNm1Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc1/nmglvsNm1Init.cpp
@@ -77,6 +77,7 @@ SECTION(".text_nmglvs") int nmglvsNm1Init()
 	//---------- start nm program ------------
 	NMGL_Context_NM1 *cntxt;
 	ImageData* imagesData;
+	int i;
 	try {
 		int fromNm0 = halSync(0xC0DE0001, 0);		// send handshake to host
 		if (fromNm0 != 0xC0DE0000) {					// get  handshake from host
@@ -92,6 +93,11 @@ SECTION(".text_nmglvs") int nmglvsNm1Init()
 	cntxt->texState.palette_pointers[0] = (NMGLubyte *)halSyncAddr(0, 0);
 	cntxt->texState.paletts_widths_pointers[0] = (unsigned int*)halSyncAddr(0, 0);
 	cntxt->polygon.stipple.pattern = (NMGLubyte *)halSyncAddr(0, 0);
+	for (int i = 1; i < NMGL_MAX_TEX_OBJECTS+1; i++)
+	{
+		cntxt->texState.palette_pointers[i] = (NMGLubyte*)cntxt->texState.palette_pointers[i-1]+NMGL_MAX_PALETTE_WIDTH*RGBA_TEXEL_SIZE_UBYTE;
+		cntxt->texState.paletts_widths_pointers[i] = (unsigned int*)((unsigned int*)cntxt->texState.paletts_widths_pointers[0]+i);
+	}
 
 		setHeap(11);
 		cntxt->patterns = myMallocT<PatternsArray>();


### PR DESCRIPTION
Осуществлено перемещение кода, инициализирующего память палитр. (Связано с настройкой тестов из папки test/nmpu0)