### PR TITLE
Fix splitTriangles

### DIFF
--- a/src_proc0/common/splitTriangles.cpp
+++ b/src_proc0/common/splitTriangles.cpp
@@ -187,8 +187,8 @@ int splitTriangles(TrianglePointers *srcVertex,
 
 	Buffer buf = initBuf((void *) dstVertex, maxDstSize);
 
-	int i = 0; // make this iterator local to assign it later to srcTreatedCount
-	for (i = 0; i < srcCount; ++i) {
+	int i = *srcTreatedCount; // make this iterator local to assign it later to srcTreatedCount
+	for (i = *srcTreatedCount; i < srcCount; ++i) {
 		// Get the triangle from the source
 		Point a;
 		Point b;


### PR DESCRIPTION
splitTriangles function must start analyzing triangles from the triangle that is
the next to the last processed one (not always from the beginning)