### PR TITLE
Fix nmglPushMatrix function

### DIFF
--- a/src_proc0/nmgl/nmglPushMatrix.cpp
+++ b/src_proc0/nmgl/nmglPushMatrix.cpp
@@ -8,8 +8,8 @@ SECTION(".text_nmgl")
 void nmglPushMatrix() {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
 	if (cntxt->currentMatrixStack->current < cntxt->currentMatrixStack->size - 1) {
-		nmblas_scopy(16, (float*)&cntxt->currentMatrixStack->base[cntxt->currentMatrixStack->size], 1,
-			(float*)&cntxt->currentMatrixStack->base[cntxt->currentMatrixStack->size + 1], 1);
+		nmblas_scopy(16, (float*)&cntxt->currentMatrixStack->base[cntxt->currentMatrixStack->current], 1,
+			(float*)&cntxt->currentMatrixStack->base[cntxt->currentMatrixStack->current + 1], 1);
 		cntxt->currentMatrixStack->current++;
 		if (cntxt->currentMatrixStack->type == NMGL_MODELVIEW_MATRIX) {
 			reverseMatrix3x3in4x4(cntxt->modelviewMatrixStack.top(), &cntxt->normalMatrix);


### PR DESCRIPTION
nmglPushMatrix copied current matrix to the end of matrix stack but it should copy
current matrix to the top of the stack.