### PR TITLE
Change pushToTriangles to implement NMGL_FLAT shade mode for triangles

### DIFF
--- a/src_proc0/common/pushToTriangles.cpp
+++ b/src_proc0/common/pushToTriangles.cpp
@@ -12,7 +12,8 @@
 SECTION(".text_demo3d")
 void pushToTriangles(const TrianglePointers &srcTriangles, Triangles& dstTriangles, int countVertex){
 
-	nmppsConvert_32f32s_rounding((nm32f*)srcTriangles.v0.color, (int*)dstTriangles.colors, 0, 4 * countVertex);
+	//v2 color is used to implement NMGL_FLAT mode for triangles
+	nmppsConvert_32f32s_rounding((nm32f*)srcTriangles.v2.color, (int*)dstTriangles.colors, 0, 4 * countVertex);
 	
 	nmblas_scopy(countVertex, srcTriangles.v0.x, 1, dstTriangles.x0, 1);
 	nmblas_scopy(countVertex, srcTriangles.v0.y, 1, dstTriangles.y0, 1);


### PR DESCRIPTION
At now one color of three (v0 color) is used for each triangle in nmOpenGL. 
At the same time one color (v2 color) should be used for NMGL_FLAT shade model.
So to implement NMGL_FLAT shade mode (nmglShadeModel function) v2 color
should be used for coloring triangles.