### PR TITLE
Fix COLOR_MATERIAL implementation

### DIFF
--- a/include/demo3d_nm0.h
+++ b/include/demo3d_nm0.h
@@ -250,10 +250,12 @@ public:
 	NMGL_SynchroMasterRingBuffer synchro;
 	BitMask segmentMasks[36];
 	v4nm32f *vertexResult;
-	v4nm32f *colorOrNormal;
+	v4nm32f *colorResult;
+	v4nm32f *normalResult;
 	v2nm32f *texResult;
 	v4nm32f *vertexResult2;
-	v4nm32f *colorOrNormal2;
+	v4nm32f *colorResult2;
+	v4nm32f *normalResult2;
 	v2nm32f *texResult2;
 
 	ImageSegments* currentSegments;
@@ -1556,7 +1558,7 @@ void updatePolygonsP(DataForNmpu1* data, Points* points, int count, v2nm32f lowe
  *  \details Функция использует контекст NMGL_Context_NM0 и находящиеся в нем массивы buffer0, buffer1, buffer2, buffer3
  */
 //! \{
-void light(v4nm32f* vertex, v4nm32f* srcNormal_dstColor, int size);
+void light(v4nm32f* vertex, v4nm32f* srcNormal, v4nm32f* src_dstColor, int size);
 //! \}
 
 void startCalculateColor(v4nm32f* srcVertex, v4nm32f* srcNormal, v4nm32f* srcColor, int vertexCount);

--- a/include/lighting.h
+++ b/include/lighting.h
@@ -32,12 +32,14 @@ struct LightingInfo {
 	int dummy;
 
 	void update(){
-		mulC_v4nm32f(lightAmbient, &materialAmbient, ambientMul, MAX_LIGHTS + 1);
-		mulC_v4nm32f(lightDiffuse, &materialDiffuse, diffuseMul, MAX_LIGHTS);
 		mulC_v4nm32f(lightSpecular, &materialSpecular, specularMul, MAX_LIGHTS);
-		nmppsAdd_32f((float*)(ambientMul + MAX_LIGHTS), 
-			(float*)&materialEmissive, 
-			(float*)(ambientMul + MAX_LIGHTS), 4);
+		if (isColorMaterial == 0) {
+			mulC_v4nm32f(lightAmbient, &materialAmbient, ambientMul, MAX_LIGHTS + 1);
+			mulC_v4nm32f(lightDiffuse, &materialDiffuse, diffuseMul, MAX_LIGHTS);
+			nmppsAdd_32f((float*)(ambientMul + MAX_LIGHTS), 
+						(float*)&materialEmissive, 
+						(float*)(ambientMul + MAX_LIGHTS), 4);
+		}
 	}
 
 	void init() {

--- a/include/lighting.h
+++ b/include/lighting.h
@@ -43,6 +43,7 @@ struct LightingInfo {
 	void init() {
 		specularExp = 0;
 		isLighting = NMGL_FALSE;
+		isColorMaterial = NMGL_FALSE;
 
 		materialAmbient.vec[0] = 0.2f;
 		materialAmbient.vec[1] = 0.2f;

--- a/nmglvs_mc12101-gcc/src_nmc0/nmgl_calculateColor.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmgl_calculateColor.cpp
@@ -7,12 +7,12 @@
 #include "nmtype.h"
 #include "nmblas.h"
 
-SECTION(".data_imu4")	v4nm32f colorValues[3 * NMGL_SIZE];
-SECTION(".data_imu4")   int colorValuesSize;
+//SECTION(".data_imu4")	v4nm32f colorValues[3 * NMGL_SIZE];
+//SECTION(".data_imu4")   int colorValuesSize;
 
 SECTION(".text_demo3d")
 void NMGL_StartCalculateColor(v4nm32f* srcVertex, v4nm32f* srcNormal, v4nm32f* srcColor, int vertexCount) {
-	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
+	/*NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
 	LightingInfo* info = &NMGL_Context_NM0::getContext()->lightingInfo;
 	colorValuesSize = vertexCount;
 	nmblas_scopy(colorValuesSize * 4, (float*)srcNormal, 1, (float*)colorValues, 1);
@@ -38,10 +38,10 @@ void NMGL_StartCalculateColor(v4nm32f* srcVertex, v4nm32f* srcNormal, v4nm32f* s
 	cntxt->tmp.vec[2] = BLUE_COEFF;
 	cntxt->tmp.vec[3] = ALPHA_COEFF;
 
-	mulC_v4nm32f((v4nm32f*)cntxt->buffer3, &cntxt->tmp, colorValues, colorValuesSize);
+	mulC_v4nm32f((v4nm32f*)cntxt->buffer3, &cntxt->tmp, colorValues, colorValuesSize);*/
 }
 
 SECTION(".text_demo3d")
 void NMGL_GetCalculatedColor(v4nm32f* dstVertex) {
-	nmblas_scopy(colorValuesSize * 4, (float*)colorValues, 1, (float*)dstVertex, 1);
+	//nmblas_scopy(colorValuesSize * 4, (float*)colorValues, 1, (float*)dstVertex, 1);
 }

--- a/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
+++ b/nmglvs_mc12101-gcc/src_nmc0/nmglvsNm0Init.cpp
@@ -31,7 +31,7 @@ SECTION(".data_imu3")	float nmgly1[NMGL_SIZE];
 SECTION(".data_imu3")	float nmglx2[NMGL_SIZE];
 SECTION(".data_imu3")	float nmgly2[NMGL_SIZE];
 SECTION(".data_imu4")	int nmglz_int[NMGL_SIZE];
-SECTION(".data_imu6")	v4nm32s nmgllightsValues[NMGL_SIZE];
+//SECTION(".data_imu6")	v4nm32s nmgllightsValues[NMGL_SIZE];
 //TEXTURING_PART
 SECTION(".data_imu1")	float nmgls0[NMGL_SIZE];
 SECTION(".data_imu2")	float nmglt0[NMGL_SIZE];
@@ -46,10 +46,10 @@ SECTION(".data_imu7")	float nmglw2[NMGL_SIZE];
 
 
 SECTION(".data_imu5")	v4nm32f vertexResult[3 * NMGL_SIZE];
-SECTION(".data_imu6")	v4nm32f colorOrNormal[3 * NMGL_SIZE];
+SECTION(".data_imu6")	v4nm32f normalResult[3 * NMGL_SIZE];
+SECTION(".data_imu2")	v4nm32f colorResult[3 * NMGL_SIZE];
 SECTION(".data_imu6")	v2nm32f texResult[3 * NMGL_SIZE];
 SECTION(".data_imu3")	v4nm32f vertexResult2[3 * NMGL_SIZE];
-SECTION(".data_imu2")	v4nm32f colorOrNormal2[3 * NMGL_SIZE];
 SECTION(".data_imu1")	v2nm32f texResult2[3 * NMGL_SIZE];
 
 SECTION(".data_imu6") int masksBits[36][3 * NMGL_SIZE / 32];
@@ -197,10 +197,12 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 		cntxt->buffer4 = (float*)nmglBuffer4;
 		cntxt->buffer5 = (float*)nmglBuffer5;
 		cntxt->vertexResult = vertexResult;
-		cntxt->colorOrNormal = colorOrNormal;
+		cntxt->colorResult = colorResult;
+		cntxt->normalResult = normalResult;
 		cntxt->texResult = texResult;
 		cntxt->vertexResult2 = vertexResult2;
-		cntxt->colorOrNormal2 = colorOrNormal2;
+		cntxt->colorResult2 = normalResult;
+		cntxt->normalResult2 = colorResult;
 		cntxt->texResult2 = texResult2;
 
 		//Allocate memory for textures.
@@ -253,7 +255,8 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 	cntxt->trianInner.w0 = nmglw0;
 	cntxt->trianInner.w1 = nmglw1;
 	cntxt->trianInner.w2 = nmglw2;
-	cntxt->trianInner.colors = nmgllightsValues;
+	//cntxt->trianInner.colors = nmgllightsValues;
+	cntxt->trianInner.colors = (v4nm32s*)normalResult;
 	cntxt->trianInner.maxSize = NMGL_SIZE;
 	cntxt->trianInner.size = 0;
 
@@ -269,7 +272,8 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 	cntxt->lineInner.t1 = nmglt1;
 	cntxt->lineInner.w0 = nmglw0;
 	cntxt->lineInner.w1 = nmglw1;
-	cntxt->lineInner.colors = nmgllightsValues;
+	//cntxt->lineInner.colors = nmgllightsValues;
+	cntxt->lineInner.colors = (v4nm32s*)normalResult;
 	cntxt->lineInner.maxSize = NMGL_SIZE;
 	cntxt->lineInner.size = 0;
 
@@ -279,7 +283,8 @@ SECTION(".text_nmglvs") int nmglvsNm0Init()
 	cntxt->pointInner.s = nmgls0;
 	cntxt->pointInner.t = nmglt0;
 	cntxt->pointInner.w = nmglw0;
-	cntxt->pointInner.colors = nmgllightsValues;
+	//cntxt->pointInner.colors = nmgllightsValues;
+	cntxt->pointInner.colors = (v4nm32s*)normalResult;
 	cntxt->pointInner.maxSize = NMGL_SIZE;
 	cntxt->pointInner.size = 0;
 	

--- a/src_proc0/common/light.cpp
+++ b/src_proc0/common/light.cpp
@@ -108,7 +108,23 @@ void light(v4nm32f* vertex, v4nm32f* srcNormal, v4nm32f* srcDstColor, int countV
 
 		nmppsAdd_32f(cntxt->buffer2, (float*)resultColor, (float*)resultColor, 4 * countVertex);
 	}
-	addC_v4nm32f((v4nm32f*)resultColor, &lightingInfo->ambientMul[MAX_LIGHTS],
-		(v4nm32f*)srcDstColor, countVertex);
+
+	if (lightingInfo->isColorMaterial == 0) {
+		addC_v4nm32f((v4nm32f*)resultColor, &lightingInfo->ambientMul[MAX_LIGHTS],
+					 (v4nm32f*)srcDstColor, countVertex);
+	} else {
+		v4nm32f *acm_mul_acs = (v4nm32f*)(cntxt->buffer2);
+		v4nm32f *acm_mul_acs_plus_ecm = (v4nm32f*)(cntxt->buffer3);
+
+		// resultColor + acm * acs + ecm
+		// acm * acs; acm = vertex colors (COLOR_MATERIAL enabled), acs = lightAmbient[MAX_LIGHTS]
+		mulC_v4nm32f(srcDstColor, &lightingInfo->lightAmbient[MAX_LIGHTS], acm_mul_acs, countVertex);
+		// acm * acs + ecm
+		addC_v4nm32f(acm_mul_acs, &lightingInfo->materialEmissive, acm_mul_acs_plus_ecm, countVertex);
+
+		nmppsAdd_32f((float*)acm_mul_acs_plus_ecm, (float*)resultColor, (float*)srcDstColor, 4 * countVertex);
+	}
+
+
 
 }

--- a/src_proc0/common/light.cpp
+++ b/src_proc0/common/light.cpp
@@ -30,7 +30,7 @@ inline void normalize_v4nm32f(v4nm32f* src, v4nm32f* dst, int size, v2nm32f* tmp
 
 
 SECTION(".text_demo3d")
-void light(v4nm32f* vertex, v4nm32f* srcNormalDstColor, int countVertex) {
+void light(v4nm32f* vertex, v4nm32f* srcNormal, v4nm32f* srcDstColor, int countVertex) {
 	NMGL_Context_NM0 *cntxt = NMGL_Context_NM0::getContext();
 	LightingInfo *lightingInfo = &cntxt->lightingInfo;
 	v4nm32f *resultColor = (v4nm32f*)cntxt->buffer4;
@@ -57,10 +57,10 @@ void light(v4nm32f* vertex, v4nm32f* srcNormalDstColor, int countVertex) {
 			(v2nm32f*)cntxt->buffer0, (v2nm32f*)cntxt->buffer3);
 		//cntxt->buffer2 = unit VP
 
-		dotV_gt0_v4nm32f(srcNormalDstColor, (v4nm32f*)cntxt->buffer2, (v2nm32f*)n_dot_vp, countVertex);
+		dotV_gt0_v4nm32f(srcNormal, (v4nm32f*)cntxt->buffer2, (v2nm32f*)n_dot_vp, countVertex);
 		//printCrc(n_dot_vp, 2 * countVertex, "n_dot_vp");
 		//printf("size=%d\n\n", countVertex);
-		//printCrc(srcNormalDstColor, 4 * countVertex, "srcn");
+		//printCrc(srcNormal, 4 * countVertex, "srcn");
 
 		cntxt->tmp.vec[0] = cntxt->tmp.vec[1] = cntxt->tmp.vec[3] = 0;
 		cntxt->tmp.vec[2] = 1;
@@ -69,7 +69,7 @@ void light(v4nm32f* vertex, v4nm32f* srcNormalDstColor, int countVertex) {
 		normalize_v4nm32f((v4nm32f*)cntxt->buffer1, (v4nm32f*)cntxt->buffer2, countVertex,
 			(v2nm32f*)cntxt->buffer0, (v2nm32f*)cntxt->buffer3);
 		//cntxt->buffer2 = unit(unit VP + h)
-		dotV_gt0_v4nm32f(srcNormalDstColor, (v4nm32f*)cntxt->buffer2, (v2nm32f*)cntxt->buffer3, countVertex);
+		dotV_gt0_v4nm32f(srcNormal, (v4nm32f*)cntxt->buffer2, (v2nm32f*)cntxt->buffer3, countVertex);
 		//printCrc(srcNormalDstColor, 4 * countVertex, "src1");
 		//printCrc(cntxt->buffer2, 4 * countVertex, "src2");
 		//printCrc(cntxt->buffer3, 2 * countVertex, "dst");
@@ -77,18 +77,38 @@ void light(v4nm32f* vertex, v4nm32f* srcNormalDstColor, int countVertex) {
 		replaceEq0_32f((float*)cntxt->buffer3, (float*)cntxt->buffer3, 2 * countVertex, 1.0f);
 		pow_32f(cntxt->buffer3, (float*)n_dot_h_in_srm, lightingInfo->specularExp, 2 * countVertex, cntxt->buffer2);
 		
-		baseLighti(lightingInfo->ambientMul + light,
-			n_dot_vp,
-			lightingInfo->diffuseMul + light,
-			n_dot_h_in_srm,
-			lightingInfo->specularMul + light,
-			(v4nm32f*)cntxt->buffer2,
-			countVertex);
+		if (lightingInfo->isColorMaterial == 0) {
+			baseLighti(lightingInfo->ambientMul + light,
+				n_dot_vp,
+				lightingInfo->diffuseMul + light,
+				n_dot_h_in_srm,
+				lightingInfo->specularMul + light,
+				(v4nm32f*)cntxt->buffer2,
+				countVertex);
+		}
+		else {
+			v4nm32f *diffuse = (v4nm32f*)(cntxt->buffer2);
+			v4nm32f *ambient = (v4nm32f*)(cntxt->buffer5);
+
+			mulC_v4nm32f(srcDstColor, lightingInfo->lightDiffuse + light, diffuse, countVertex);
+			mulC_v4nm32f(srcDstColor, lightingInfo->lightAmbient + light, ambient, countVertex);
+
+			// ambient + n_dot_vp * diffuse + n_dot_h_in_srm * specular
+			// n_dot_vp * diffuse
+			dotMulV_v4nm32f(n_dot_vp, diffuse, (v4nm32f *)cntxt->buffer3, countVertex);
+			//ambient + n_dot_vp * diffuse
+			nmppsAdd_32f((float*)cntxt->buffer3, (float*)ambient, (float*)cntxt->buffer2, 4 * countVertex);
+			//n_dot_h_in_srm * specular
+			//void dotMulC_Add_v4nm32f(v2nm32f* srcVec, v4nm32f* mulC, v4nm32f* addVec, v4nm32f* dst, int size);
+			dotMulC_Add_v4nm32f(n_dot_h_in_srm, lightingInfo->specularMul + light, (v4nm32f*)cntxt->buffer2, (v4nm32f*)cntxt->buffer3, countVertex);
+
+			nmblas_scopy(4 * countVertex, cntxt->buffer3, 1, cntxt->buffer2, 1);
+			
+		}
 
 		nmppsAdd_32f(cntxt->buffer2, (float*)resultColor, (float*)resultColor, 4 * countVertex);
 	}
 	addC_v4nm32f((v4nm32f*)resultColor, &lightingInfo->ambientMul[MAX_LIGHTS],
-		(v4nm32f*)srcNormalDstColor, countVertex);
+		(v4nm32f*)srcDstColor, countVertex);
 
-	
 }

--- a/src_proc0/nmgl/nmglDrawArrays.cpp
+++ b/src_proc0/nmgl/nmglDrawArrays.cpp
@@ -195,14 +195,27 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 			else {
 				normalAM.pop(cntxt->buffer1);
 			}
-			mul_v4nm32f_mat4nm32f((v4nm32f*)cntxt->buffer1, &cntxt->normalMatrix, cntxt->colorOrNormal, localSize);
+			mul_v4nm32f_mat4nm32f((v4nm32f*)cntxt->buffer1, &cntxt->normalMatrix, cntxt->normalResult, localSize);
 			if (cntxt->normalizeEnabled) {
-				nmblas_scopy(4 * localSize, (float*)cntxt->colorOrNormal, 1, cntxt->buffer2, 1);
-				dotV_v4nm32f(cntxt->colorOrNormal, (v4nm32f*)cntxt->buffer2, (v2nm32f*)cntxt->buffer0, localSize);
+				nmblas_scopy(4 * localSize, (float*)cntxt->normalResult, 1, cntxt->buffer2, 1);
+				dotV_v4nm32f(cntxt->normalResult, (v4nm32f*)cntxt->buffer2, (v2nm32f*)cntxt->buffer0, localSize);
 				fastInvSqrt(cntxt->buffer0, cntxt->buffer1, 2 * localSize);
-				dotMulV_v4nm32f((v2nm32f*)cntxt->buffer1, (v4nm32f*)cntxt->buffer2, cntxt->colorOrNormal, localSize);
+				dotMulV_v4nm32f((v2nm32f*)cntxt->buffer1, (v4nm32f*)cntxt->buffer2, cntxt->normalResult, localSize);
 			}
 		}
+		//else {
+		//	set_v4nm32f(cntxt->normalResult, cntxt->currentNormal, localSize);
+		//}
+
+		//
+		if (cntxt->colorArray.enabled) {
+			colorAM.pop(cntxt->colorResult);
+			if (cntxt->colorArray.type == NMGL_UNSIGNED_BYTE) {
+				nmppsConvert_32s32f((int*)cntxt->colorResult, cntxt->buffer0, cntxt->colorArray.size * localSize);
+				nmppsMulC_32f(cntxt->buffer0, (float*)cntxt->colorResult, 1.0 / 255.0, cntxt->colorArray.size * localSize);
+			}
+		}
+
 
 		//vertex in vertexResult
 		//normal in colorOrNormal
@@ -210,31 +223,25 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 		//nmprofiler_enable();
 		if (cntxt->lightingInfo.isLighting) {
 			PROFILER_SIZE(localSize);
-			light(cntxt->vertexResult, cntxt->colorOrNormal, localSize);
+			light(cntxt->vertexResult, cntxt->normalResult, cntxt->colorResult, localSize);
 		}
 		else {
 			cntxt->tmp.vec[0] = 1;
 			cntxt->tmp.vec[1] = 1;
 			cntxt->tmp.vec[2] = 1;
 			cntxt->tmp.vec[3] = 1;
-			set_v4nm32f(cntxt->colorOrNormal, &cntxt->tmp, localSize);
+			set_v4nm32f(cntxt->colorResult, &cntxt->tmp, localSize);
 		}
 		//nmprofiler_disable();
 		//color
-		if (cntxt->colorArray.enabled) {
-			colorAM.pop(cntxt->colorOrNormal);
-			if (cntxt->colorArray.type == NMGL_UNSIGNED_BYTE) {
-				nmppsConvert_32s32f((int*)cntxt->colorOrNormal, cntxt->buffer0, cntxt->colorArray.size * localSize);
-				nmppsMulC_32f(cntxt->buffer0, (float*)cntxt->colorOrNormal, 1.0 / 255.0, cntxt->colorArray.size * localSize);
-			}
-		}
-		clamp_32f((float*)cntxt->colorOrNormal, 0, 1, (float*)cntxt->buffer3, 4 * localSize);
+		
+		clamp_32f((float*)cntxt->colorResult, 0, 1, (float*)cntxt->buffer3, 4 * localSize);
 		cntxt->tmp.vec[0] = RED_COEFF;
 		cntxt->tmp.vec[1] = GREEN_COEFF;
 		cntxt->tmp.vec[2] = BLUE_COEFF;
 		cntxt->tmp.vec[3] = ALPHA_COEFF;
 
-		mulC_v4nm32f((v4nm32f*)cntxt->buffer3, &cntxt->tmp, cntxt->colorOrNormal, localSize);
+		mulC_v4nm32f((v4nm32f*)cntxt->buffer3, &cntxt->tmp, cntxt->colorResult, localSize);
 
 		//умножение на матрицу проекции (Projection matrix)
 		mul_mat4nm32f_v4nm32f(cntxt->projectionMatrixStack.top(), cntxt->vertexResult, (v4nm32f*)cntxt->vertexResult, localSize);
@@ -265,9 +272,9 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 				trianPointers.v1.w = (float*)cntxt->vertexResult2 + 10 * NMGL_SIZE;
 				trianPointers.v2.w = (float*)cntxt->vertexResult2 + 11 * NMGL_SIZE;
 
-				trianPointers.v0.color = (cntxt->colorOrNormal2 + 0 * NMGL_SIZE);
-				trianPointers.v1.color = (cntxt->colorOrNormal2 + 1 * NMGL_SIZE);
-				trianPointers.v2.color = (cntxt->colorOrNormal2 + 2 * NMGL_SIZE);
+				trianPointers.v0.color = (cntxt->colorResult2 + 0 * NMGL_SIZE);
+				trianPointers.v1.color = (cntxt->colorResult2 + 1 * NMGL_SIZE);
+				trianPointers.v2.color = (cntxt->colorResult2 + 2 * NMGL_SIZE);
 
 				trianPointers.v0.s = (float*)cntxt->texResult2 + 0 * NMGL_SIZE;
 				trianPointers.v0.t = (float*)cntxt->texResult2 + 1 * NMGL_SIZE;
@@ -290,9 +297,9 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 				trianPointers2.v1.w = (float*)cntxt->vertexResult + 10 * NMGL_SIZE;
 				trianPointers2.v2.w = (float*)cntxt->vertexResult + 11 * NMGL_SIZE;
 
-				trianPointers2.v0.color = (cntxt->colorOrNormal + 0 * NMGL_SIZE);
-				trianPointers2.v1.color = (cntxt->colorOrNormal + 1 * NMGL_SIZE);
-				trianPointers2.v2.color = (cntxt->colorOrNormal + 2 * NMGL_SIZE);
+				trianPointers2.v0.color = (cntxt->colorResult + 0 * NMGL_SIZE);
+				trianPointers2.v1.color = (cntxt->colorResult + 1 * NMGL_SIZE);
+				trianPointers2.v2.color = (cntxt->colorResult + 2 * NMGL_SIZE);
 
 				trianPointers2.v0.s = (float*)cntxt->texResult + 0 * NMGL_SIZE;
 				trianPointers2.v0.t = (float*)cntxt->texResult + 1 * NMGL_SIZE;
@@ -305,13 +312,13 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 			int primCount = 0;
 			switch (mode) {
 			case NMGL_TRIANGLES:
-				primCount = repackToPrimitives_t((v4nm32f*)cntxt->vertexResult, (v4nm32f*)cntxt->colorOrNormal, (v2nm32f*)cntxt->texResult, &trianPointers, localSize);
+				primCount = repackToPrimitives_t((v4nm32f*)cntxt->vertexResult, (v4nm32f*)cntxt->colorResult, (v2nm32f*)cntxt->texResult, &trianPointers, localSize);
 				break;
 			case NMGL_TRIANGLE_FAN:
-				primCount = repackToPrimitives_tf((v4nm32f*)cntxt->vertexResult, (v4nm32f*)cntxt->colorOrNormal, (v2nm32f*)cntxt->texResult, &trianPointers, localSize);
+				primCount = repackToPrimitives_tf((v4nm32f*)cntxt->vertexResult, (v4nm32f*)cntxt->colorResult, (v2nm32f*)cntxt->texResult, &trianPointers, localSize);
 				break;
 			case NMGL_TRIANGLE_STRIP:
-				primCount = repackToPrimitives_ts((v4nm32f*)cntxt->vertexResult, (v4nm32f*)cntxt->colorOrNormal, (v2nm32f*)cntxt->texResult, &trianPointers, localSize);
+				primCount = repackToPrimitives_ts((v4nm32f*)cntxt->vertexResult, (v4nm32f*)cntxt->colorResult, (v2nm32f*)cntxt->texResult, &trianPointers, localSize);
 				break;
 			}
 			//------------clipping-------------------
@@ -423,13 +430,13 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 //TEXTURING_PART
 			switch (mode) {
 			case NMGL_LINES:
-				primCount = repackToPrimitives_l(cntxt->vertexResult, cntxt->colorOrNormal, cntxt->texResult, &linePointers, localSize);
+				primCount = repackToPrimitives_l(cntxt->vertexResult, cntxt->colorResult, cntxt->texResult, &linePointers, localSize);
 				break;
 			case NMGL_LINE_LOOP:
-				primCount = repackToPrimitives_ll(cntxt->vertexResult, cntxt->colorOrNormal, cntxt->texResult, &linePointers, localSize);
+				primCount = repackToPrimitives_ll(cntxt->vertexResult, cntxt->colorResult, cntxt->texResult, &linePointers, localSize);
 				break;
 			case NMGL_LINE_STRIP:
-				primCount = repackToPrimitives_ls(cntxt->vertexResult, cntxt->colorOrNormal, cntxt->texResult, &linePointers, localSize);
+				primCount = repackToPrimitives_ls(cntxt->vertexResult, cntxt->colorResult, cntxt->texResult, &linePointers, localSize);
 				break;
 			}
 			
@@ -477,7 +484,7 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 			perpectiveDivView(pointers, cntxt->windowInfo, cntxt->buffer0, localSize);
 
 			nmppsConvert_32f32s_rounding(cntxt->buffer0, cntxt->pointInner.z, 0, localSize);
-			nmppsConvert_32f32s_rounding((float*)cntxt->colorOrNormal, (int*)cntxt->pointInner.colors, 0, 4 * localSize);
+			nmppsConvert_32f32s_rounding((float*)cntxt->colorResult, (int*)cntxt->pointInner.colors, 0, 4 * localSize);
 
 			nmppsSubC_32f(cntxt->pointInner.x, cntxt->buffer0, cntxt->pointRadius, localSize);
 			nmppsSubC_32f(cntxt->pointInner.y, cntxt->buffer1, cntxt->pointRadius, localSize);

--- a/src_proc0/nmgl/nmglDrawArrays.cpp
+++ b/src_proc0/nmgl/nmglDrawArrays.cpp
@@ -214,6 +214,12 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 				nmppsConvert_32s32f((int*)cntxt->colorResult, cntxt->buffer0, cntxt->colorArray.size * localSize);
 				nmppsMulC_32f(cntxt->buffer0, (float*)cntxt->colorResult, 1.0 / 255.0, cntxt->colorArray.size * localSize);
 			}
+		} else{
+			cntxt->tmp.vec[0] = 1;
+			cntxt->tmp.vec[1] = 1;
+			cntxt->tmp.vec[2] = 1;
+			cntxt->tmp.vec[3] = 1;
+			set_v4nm32f(cntxt->colorResult, &cntxt->tmp, localSize);
 		}
 
 
@@ -224,13 +230,6 @@ void nmglDrawArrays(NMGLenum mode, NMGLint first, NMGLsizei count) {
 		if (cntxt->lightingInfo.isLighting) {
 			PROFILER_SIZE(localSize);
 			light(cntxt->vertexResult, cntxt->normalResult, cntxt->colorResult, localSize);
-		}
-		else {
-			cntxt->tmp.vec[0] = 1;
-			cntxt->tmp.vec[1] = 1;
-			cntxt->tmp.vec[2] = 1;
-			cntxt->tmp.vec[3] = 1;
-			set_v4nm32f(cntxt->colorResult, &cntxt->tmp, localSize);
 		}
 		//nmprofiler_disable();
 		//color


### PR DESCRIPTION
This pull request fixes the implementation of GL_COLOR_MATERIAL mode.

The glEnable(GL_COLOR_MATERIAL) mode, added in commit ae35666, was not implemented quite correctly: in the lighting equation in nmglDrawArrays() with the COLOR_MATERIAL mode enabled, the a\_cm and d\_cm parameters must be vectors composed of colors that were specified in all glColor4f calls. This follows from the fact that:
    * When the GL_COLOR_MATERIAL mode is on, the lighting equation should use the current color (set, for example, with glColor4f) in the a\_cm, d\_cm parameters.
    * The Begin/End is implemented via nmglDrawArrays(). All glColor4f calls that set the current color are converted to a vector of the current colors.
    * The colors of the vertices are calculated using the lighting equation in nmglDrawArrays().
But in the commit ae35666, instead of vectors, a scalar value was used (equal to the color set during the last call to the glColor4f function), which is incorrect.

This pull request introduces the following changes:
* Commits from the test_light branch partially fix the incorrect implementation of GL_COLOR_MATERIAL (calculations with a\_cm and d\_cm are vectorized). But:
    * The a\_cm\*a\_cli computation is vectorized, but the a\_cm*a\_cs+e\_cm computation must also be vectorized.
    * If GL_COLOR_MATERIAL is enabled, then calculations in the LightingInfo.update() function (except for specularMul) that implement a\_cm\*a\_cli+a\_cm\*a\_cs+e\_cm should not be performed, since then these calculations should be performed in nmglDrawArrays in vector form and with different a\_cm values.
* The last commit adds the vectorization of the a\_cm*a\_cs+e\_cm computation accordingly, and also modifies LightingInfo.update() as noted above.