### PR TITLE
Fix build errors for unit tests, testperf tests and nmopengl-x86 lib

### DIFF
--- a/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu0_gcc/Makefile
@@ -52,8 +52,8 @@ include 		 nmc4vars_win.mk
 PROJECT          = main0
 OUT_DIR          = .
 TARGET           = $(OUT_DIR)/$(PROJECT).abs
-INC_DIRS         = -I"$(NMPP)/include" -I$(HAL)/include -I$(ROOT)/include -I$(ROOT)/utilities/include
-SRC_DIRS 	     = ../../../../src_proc0/nm ../../../../utilities/src/float ..
+INC_DIRS         = -I"$(NMPP)/include" -I$(HAL)/include -I$(ROOT)/include -I$(ROOT)/utilities/include -I$(ROOT)/context/include
+SRC_DIRS 	     = ../../../../src_proc0/nm ..
 LIB_DIRS         = -L "$(NMC_GCC_TOOLPATH)/nmc4-ide/lib" -L"$(NMPP)/lib" -L"$(HAL)/lib" -L "../../../../lib"
 TMP_DIR          = Release
 #-------------- RELEASE/ALL config -------------------
@@ -61,7 +61,7 @@ CC 				 = nmc-g++
 AS               = nmc-as 				 
 AS_FLAGS    	 = -split_sir -nmc4_float
 CC_FLAGS	 	 = -std=c++11 -fno-builtin-printf -mnmc4-float
-LIBS             = -lnmopengl-nmc4f -lnmpp-nmc4f -lhal-mc12101 
+LIBS             = -lnmopengl_nmc4f -lnmpp-nmc4f -lhal-mc12101 
 LINKER_FLAGS     =   -Xlinker -Map=.main0.map $(LIB_DIRS) "-Wl,-Tldscript-nmc0.ld"  -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o$(TARGET)
 #=================== SOURCE & OBJECTS COLLECTION ===========================
 
@@ -82,7 +82,7 @@ OBJECTS_C   = $(notdir $(patsubst %.c,%.o,$(ALL_C)))
 OBJECTS     = $(addprefix $(TMP_DIR)/, $(OBJECTS_C) $(OBJECTS_CPP)  $(OBJECTS_ASM))
 
 #======================== BUILD RULES ====================================
-.PHONY:all  clean skip
+.PHONY:all  clean skip lib
 
 .DEFAULT_GOAL=default
 default: $(TARGET) 
@@ -100,11 +100,14 @@ run: $(TARGET)
 $(TMP_DIR):
 	-mkdir "$(@)"
 
-$(TARGET): $(TMP_DIR) $(OBJECTS) nmc4vars_win.mk Makefile
+$(TARGET): $(TMP_DIR) $(OBJECTS) nmc4vars_win.mk Makefile lib
 	$(CC) $(CC_FLAGS) $(LINKER_FLAGS) $(OBJECTS) $(LIBS)
 
 nmc4vars_win.mk:
 	copy "$(NMC_GCC_TOOLPATH)\nmc4-ide\include\nmc4vars_win.mk" nmc4vars_win.mk
+
+lib:
+	$(MAKE) -C $(ROOT)/make float 
 
 $(OUT_DIR): 
 	-mkdir "$(@)"

--- a/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
+++ b/app/templates/sometest/make_mc12101_nmpu1_gcc/Makefile
@@ -53,7 +53,7 @@ include 		 nmc4vars_win.mk
 PROJECT          = main1
 OUT_DIR          = .
 TARGET           = $(OUT_DIR)/$(PROJECT).abs
-INC_DIRS         = -I"$(NMPP)/include" -I$(HAL)/include -I$(ROOT)/include
+INC_DIRS         = -I"$(NMPP)/include" -I$(HAL)/include -I$(ROOT)/include -I$(ROOT)/utilities/include -I$(ROOT)/context/include
 SRC_DIRS 		 = $(ROOT)/src_proc1/nm ..
 LIB_DIRS         = -L "$(NMC_GCC_TOOLPATH)/nmc4-ide/lib" -L"$(NMPP)/lib" -L"$(HAL)/lib" -L"../../../../lib"
 TMP_DIR          = Release
@@ -62,7 +62,7 @@ CC 				 = nmc-g++
 AS               = nmc-as 				 
 AS_FLAGS    	 = -q -split_sir -nmc4_fixed
 CC_FLAGS		 = -std=c++11 -fno-builtin-printf
-LIBS             = -lnmopengl-nmc4 -lnmpp-nmc4 -lhal-mc12101 
+LIBS             = -lnmopengl_nmc4 -lnmpp-nmc4 -lhal-mc12101 
 LINKER_FLAGS     =   -Xlinker -Map=.main1.map $(LIB_DIRS) "-Wl,-Tldscript-nmc1.ld"  -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o$(TARGET)
 #=================== SOURCE & OBJECTS COLLECTION ===========================
 
@@ -83,7 +83,7 @@ OBJECTS_C   = $(notdir $(patsubst %.c,%.o,$(ALL_C)))
 OBJECTS     = $(addprefix $(TMP_DIR)/, $(OBJECTS_C) $(OBJECTS_CPP)  $(OBJECTS_ASM))
 
 #======================== BUILD RULES ====================================
-.PHONY:all  clean skip
+.PHONY:all  clean skip lib
 
 .DEFAULT_GOAL=default
 default: $(TARGET) 
@@ -101,8 +101,11 @@ run: $(TARGET)
 $(TMP_DIR):
 	-mkdir "$(@)"
 
-$(TARGET): $(TMP_DIR) $(OBJECTS) nmc4vars_win.mk Makefile
+$(TARGET): $(TMP_DIR) $(OBJECTS) nmc4vars_win.mk Makefile lib
 	$(CC) $(LINKER_FLAGS) $(OBJECTS) $(LIBS)
+
+lib:
+	$(MAKE) -C $(ROOT)/make fixed 
 
 nmc4vars_win.mk:
 	copy "$(NMC_GCC_TOOLPATH)\nmc4-ide\include\nmc4vars_win.mk" nmc4vars_win.mk

--- a/app/templates/sometest/make_x86/Makefile
+++ b/app/templates/sometest/make_x86/Makefile
@@ -6,7 +6,9 @@ PROJECT = test-x86
 #TARGET  = $(call OSX,bin/Release/$(PROJECT))
 TARGET  = bin/Release/$(PROJECT)
 
-vs2015:    	$(PROJECT).vcxproj
+.PHONY: lib
+
+vs2015:    	$(PROJECT).vcxproj lib
 #	"$(VS140COMNTOOLS)vsvars32" && msbuild $(PROJECT).vcxproj
 	"$(VS140COMNTOOLS)vsvars32" && msbuild $(PROJECT).vcxproj /p:Configuration=Release
 
@@ -35,5 +37,8 @@ $(PROJECT).vcxproj :	premake5.lua
 	
 $(PROJECT).vcproj :	premake5.lua 
 	premake5 vs2005
+
+lib:
+	make -C $(ROOT)/make x86
 
 include $(ROOT)/clean.mk	

--- a/app/templates/sometest/make_x86/premake5.lua
+++ b/app/templates/sometest/make_x86/premake5.lua
@@ -9,7 +9,7 @@
       files { "../*.cpp", "../../../../src_proc0/pc/*.cpp","../../../../src_proc0/pc/*.c","../../../../src_proc1/pc/*.cpp", "../../../../src_proc1/pc/*.c" }
 	  links { "nmopengl-x86.lib", "nmpp-x86.lib", "hal-virtual-x86.lib", "tinyxml.lib" }
 	  libdirs { "$(NMPP)/lib", "$(HAL)/lib", "$(TINYXML)", "../../../../lib"}
-	  includedirs { "../../../../include", "$(NMPP)/include", "$(HAL)/include", "$(TINYXML)"}
+	  includedirs { "../../../../include", "$(NMPP)/include", "$(HAL)/include", "$(TINYXML)", "../../../../utilities/include", "../../../../context/include"}
 
       configuration "Debug"
          defines { "DEBUG" }

--- a/make/premake5.lua
+++ b/make/premake5.lua
@@ -12,13 +12,13 @@ solution "nmopengl-x86"
 				"../src_proc0/nmgl/*.*",
 				"../src_proc1/common/*.*",
 				"../src_proc1/pc/*.*",
-				"../utilities/common/*.c*",
-				"../utilities/common/pc/*.c*",
-				"../utilities/fixed/*.c*",
-				"../utilities/fixed/pc/*.c*",
-				"../utilities/float/*.c*",
-				"../utilities/float/pc/*.c*",}
-	  includedirs { "../include", "$(NMPP)/include", "$(HAL)/include", "../utilities/include"}
+				"../utilities/src/common/*.c*",
+				"../utilities/src/common/pc/*.c*",
+				"../utilities/src/fixed/*.c*",
+				"../utilities/src/fixed/pc/*.c*",
+				"../utilities/src/float/*.c*",
+				"../utilities/src/float/pc/*.c*",}
+	  includedirs { "../include", "$(NMPP)/include", "$(HAL)/include", "../utilities/include", "../context/include"}
 	  targetdir ("../lib")
 	  
 	  configuration {"Debug","x86"}

--- a/test/perf/mai/make_mc12101_nmpu0-ld/Makefile
+++ b/test/perf/mai/make_mc12101_nmpu0-ld/Makefile
@@ -22,13 +22,14 @@ AS       = nmc-gcc
 CC_FLAGS = -std=c++11 -O2 -Wall -mnmc4-float
 PROJECT  = main
 TARGET   =$(PROJECT)
-INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include
+INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include -I$(ROOT)/utilities/include -I$(ROOT)/context/include
 LIB_DIRS = -L"$(NMCGCC)/lib" -L"$(NMCGCC)/nmc/lib/nmc4" -L"$(NMPP)/lib" -L"$(HAL)/lib" -L$(ROOT)/lib
-LIBS     = -lnmopengl-nmc4f -lnmpp-nmc4f -lhal-mc12101
-
+LIBS     = -lnmopengl_nmc4f -lnmpp-nmc4f -lhal-mc12101
 CFG      =  "-Wl,-Tmc12101board-nmpu0.ld"
 
-$(TARGET): $(SRC_CPP) Makefile
+.PHONY: lib 
+
+$(TARGET): $(SRC_CPP) Makefile lib
 	$(CC) $(CC_FLAGS) main.cpp $(INC_DIRS) $(LIB_DIRS) $(LIBS) -lc $(CFG) -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o $(TARGET) $(ERRECHO)
 
 PATH:=$(MC12101)/bin;$(PATH)
@@ -48,4 +49,6 @@ reset:
 	
 nmc4vars_win.mk:
 	copy "$(NMC_GCC_TOOLPATH)\nmc4-ide\include\nmc4vars_win.mk" nmc4vars_win.mk
-	
+
+lib:
+	$(MAKE) -C $(ROOT)/make float

--- a/test/perf/mai/make_mc12101_nmpu1-ld/Makefile
+++ b/test/perf/mai/make_mc12101_nmpu1-ld/Makefile
@@ -23,12 +23,14 @@ AS       = nmc-gcc
 CC_FLAGS = -std=c++11 -O2 -Wall -mnmc4
 PROJECT  = main
 TARGET   =$(PROJECT)
-INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include
+INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include -I$(ROOT)/utilities/include -I$(ROOT)/context/include
 LIB_DIRS = -L"$(NMCGCC)/lib" -L"$(NMCGCC)/nmc/lib/nmc4" -L"$(NMPP)/lib" -L"$(HAL)/lib" -L$(ROOT)/lib
-LIBS     = -lnmopengl-nmc4 -lnmpp-nmc4 -lhal-mc12101
+LIBS     = -lnmopengl_nmc4 -lnmpp-nmc4 -lhal-mc12101
 CFG      =  "-Wl,-Tmc12101board-nmpu1.ld"
 
-$(TARGET): $(SRC_CPP) Makefile
+.PHONY: lib 
+
+$(TARGET): $(SRC_CPP) Makefile lib
 	$(CC) $(CC_FLAGS) main.cpp $(INC_DIRS) $(LIB_DIRS) $(LIBS) -lc $(CFG) -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o $(TARGET)  $(ERRECHO)
 
 PATH:=$(MC12101)/bin;$(PATH)
@@ -48,3 +50,6 @@ reset:
 
 nmc4vars_win.mk:
 	copy "$(NMC_GCC_TOOLPATH)\nmc4-ide\include\nmc4vars_win.mk" nmc4vars_win.mk
+
+lib:
+	$(MAKE) -C $(ROOT)/make fixed 

--- a/test/perf/rcm/make_mc12101_nmpu0-ld/Makefile
+++ b/test/perf/rcm/make_mc12101_nmpu0-ld/Makefile
@@ -22,13 +22,14 @@ AS       = nmc-gcc
 CC_FLAGS = -std=c++11 -O2 -Wall -mnmc4-float
 PROJECT  = main
 TARGET   =$(PROJECT)
-INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include
+INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include -I$(ROOT)/utilities/include -I$(ROOT)/context/include
 LIB_DIRS = -L"$(NMCGCC)/lib" -L"$(NMCGCC)/nmc/lib/nmc4" -L"$(NMPP)/lib" -L"$(HAL)/lib" -L$(ROOT)/lib
-LIBS     = -lnmopengl-nmc4f -lnmpp-nmc4f -lhal-mc12101
-
+LIBS     = -lnmopengl_nmc4f -lnmpp-nmc4f -lhal-mc12101
 CFG      =  "-Wl,-Tmc12101board-nmpu0.ld"
 
-$(TARGET): $(SRC_CPP) Makefile
+.PHONY: lib 
+
+$(TARGET): $(SRC_CPP) Makefile lib
 	$(CC) $(CC_FLAGS) main.cpp $(INC_DIRS) $(LIB_DIRS) $(LIBS) -lc $(CFG) -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o $(TARGET) $(ERRECHO)
 
 PATH:=$(MC12101)/bin;$(PATH)
@@ -48,4 +49,6 @@ reset:
 	
 nmc4vars_win.mk:
 	copy "$(NMC_GCC_TOOLPATH)\nmc4-ide\include\nmc4vars_win.mk" nmc4vars_win.mk
-	
+
+lib:
+	$(MAKE) -C $(ROOT)/make float

--- a/test/perf/rcm/make_mc12101_nmpu1-ld/Makefile
+++ b/test/perf/rcm/make_mc12101_nmpu1-ld/Makefile
@@ -23,12 +23,14 @@ AS       = nmc-gcc
 CC_FLAGS = -std=c++11 -O2 -Wall -mnmc4
 PROJECT  = main
 TARGET   =$(PROJECT)
-INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include
+INC_DIRS = -I"$(NMPP)/include" -I"$(HAL)/include" -I$(ROOT)/include -I$(ROOT)/utilities/include -I$(ROOT)/context/include
 LIB_DIRS = -L"$(NMCGCC)/lib" -L"$(NMCGCC)/nmc/lib/nmc4" -L"$(NMPP)/lib" -L"$(HAL)/lib" -L$(ROOT)/lib
-LIBS     = -lnmopengl-nmc4 -lnmpp-nmc4 -lhal-mc12101
+LIBS     = -lnmopengl_nmc4 -lnmpp-nmc4 -lhal-mc12101
 CFG      =  "-Wl,-Tmc12101board-nmpu1.ld"
 
-$(TARGET): $(SRC_CPP) Makefile
+.PHONY: lib 
+
+$(TARGET): $(SRC_CPP) Makefile lib
 	$(CC) $(CC_FLAGS) main.cpp $(INC_DIRS) $(LIB_DIRS) $(LIBS) -lc $(CFG) -Wl,--whole-archive -lmc12101 -Wl,--no-whole-archive -o $(TARGET)  $(ERRECHO)
 
 PATH:=$(MC12101)/bin;$(PATH)
@@ -48,3 +50,6 @@ reset:
 
 nmc4vars_win.mk:
 	copy "$(NMC_GCC_TOOLPATH)\nmc4-ide\include\nmc4vars_win.mk" nmc4vars_win.mk
+
+lib:
+	$(MAKE) -C $(ROOT)/make fixed 


### PR DESCRIPTION
* Add 'lib' target and prerequisite to unit tests (mc12101 and x86)
  and testperf tests so we don't rebuild libnmopengl manually.
* Add include directories for context and utilities directories
* Fix names of linked nmOpengl libraries because they were changed in
  make/Makefile.
* Fix building of nmopengl-x86,x64,x86d,x64d - there were wrong paths
  for sources (utilities and context directories)